### PR TITLE
Add FSL91030 and MilkV Vega support

### DIFF
--- a/board/milkv/vega/README.md
+++ b/board/milkv/vega/README.md
@@ -1,0 +1,151 @@
+TamaGo - bare metal Go - MilkV Vega support
+===========================================
+
+tamago | https://github.com/usbarmory/tamago
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+Marvin Drees
+marvin.drees@9elements.com
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The [vega](https://github.com/usbarmory/tamago/tree/master/board/milkv/vega)
+package provides support for the [MilkV Vega](https://milkv.io/vega) board, a
+RISC-V switch board powered by the Fisilink FSL91030 SoC (Nuclei UX600 core,
+240 MB DRAM, 64 MB NOR flash).
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For more information about TamaGo see its
+[repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki).
+
+For the underlying driver support for this board see package
+[fsl91030](https://github.com/usbarmory/tamago/tree/master/soc/fisilink/fsl91030).
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| SoC               | Board                               | SoC package                                                                       | Board package                                                            |
+|-------------------|-------------------------------------|-----------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| Fisilink FSL91030 | [MilkV Vega](https://milkv.io/vega) | [fsl91030](https://github.com/usbarmory/tamago/tree/master/soc/fisilink/fsl91030) | [vega](https://github.com/usbarmory/tamago/tree/master/board/milkv/vega) |
+
+Compiling
+=========
+
+Go distribution supporting `GOOS=tamago`
+---------------------------------------
+
+The [tamago](https://github.com/usbarmory/tamago/tree/latest/cmd/tamago)
+command downloads, compiles, and runs the `go` command from the
+[TamaGo distribution](https://github.com/usbarmory/tamago-go) matching the
+tamago module version from the application `go.mod`.
+
+Applications can add `github.com/usbarmory/tamago` to `go.mod`, and then
+replace the `go` command with:
+
+```sh
+go run github.com/usbarmory/tamago/cmd/tamago
+```
+
+Alternatively the
+[latest TamaGo distribution](https://github.com/usbarmory/tamago-go/tree/latest)
+can be manually built:
+
+```sh
+wget https://github.com/usbarmory/tamago-go/archive/refs/tags/latest.zip
+unzip latest.zip
+cd tamago-go-latest/src && ./all.bash
+cd ../bin && export TAMAGO=`pwd`/go
+```
+
+Building applications
+---------------------
+
+Go applications are required to set `GOOSPKG` to the desired
+[runtime/goos](https://github.com/usbarmory/tamago-go/tree/latest/src/runtime/goos)
+overlay and import the relevant board package:
+
+```golang
+import (
+	_ "github.com/usbarmory/tamago/board/milkv/vega"
+)
+```
+
+The image is linked to run from DRAM (text segment at DRAM base + 64 KB):
+
+```sh
+GOOS=tamago GOOSPKG=github.com/usbarmory/tamago GOARCH=riscv64 \
+	${TAMAGO} build -ldflags "-T 0x41010000 -R 0x1000" main.go
+```
+
+The ELF entry point differs from the `-T` text base; extract it for the loader:
+
+```sh
+riscv64-linux-gnu-readelf -h main | awk '/Entry point/{print $4}'
+```
+
+Build tags
+==========
+
+The following build tags allow applications to override the package own
+definition for the `runtime/goos` overlay:
+
+* `linkcpuinit`: include the board reset vector that initializes DDR, cache and
+  the FPU (for loading directly into DRAM, e.g. via JTAG)
+* `linkramsize`: exclude `ramSize` from `mem.go`
+* `linkprintk`: exclude `printk` from `console.go`
+
+Executing
+=========
+
+The board boots from NOR flash. A TamaGo image is linked to run from DRAM, so a
+first stage must initialize DDR and relocate the image before jumping to it.
+Two options are available:
+
+* load the image into DRAM with the on-board vendor bootloader (e.g. U-Boot
+  `bootelf` against the ELF `e_entry`), or
+* flash a small relocating stage ahead of the image; an example `flashboot`
+  stub for this is provided with the TamaGo examples.
+
+For emulation under the Nuclei QEMU fork see the
+[eval_soc](https://github.com/usbarmory/tamago/tree/master/board/nuclei/eval_soc)
+board package.
+
+Standard output
+---------------
+
+The standard output is exposed on UART0 (115200 8N1):
+
+```sh
+picocom -b 115200 -eb /dev/ttyUSB0 --imap lfcrlf
+```
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/board/milkv/vega/console.go
+++ b/board/milkv/vega/console.go
@@ -1,0 +1,22 @@
+// MilkV Vega support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkprintk
+
+package vega
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/fisilink/fsl91030"
+)
+
+//go:linkname printk runtime/goos.Printk
+func printk(c byte) {
+	fsl91030.UART0.Tx(c)
+}

--- a/board/milkv/vega/mem.go
+++ b/board/milkv/vega/mem.go
@@ -1,0 +1,20 @@
+// MilkV Vega support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkramsize
+
+package vega
+
+import (
+	_ "unsafe"
+)
+
+// Applications can override ramSize with the `linkramsize` build tag.
+
+//go:linkname ramSize runtime/goos.RamSize
+var ramSize uint64 = 0x0f000000 // 240 MB

--- a/board/milkv/vega/vega.go
+++ b/board/milkv/vega/vega.go
@@ -1,0 +1,40 @@
+// MilkV Vega support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package vega provides hardware initialization, automatically on import,
+// for the MilkV Vega board equipped with the Fisilink FSL91030 SoC
+// (Nuclei UX600 RV64IMAFDC core, 240 MB DRAM at 0x41000000).
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=riscv64` as
+// supported by the TamaGo framework for bare metal Go on RISC-V SoCs, see
+// https://github.com/usbarmory/tamago.
+package vega
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/fisilink/fsl91030"
+)
+
+// Peripheral instances
+var (
+	UART0 = fsl91030.UART0
+	UART1 = fsl91030.UART1
+)
+
+// Init takes care of the lower level initialization triggered early in runtime
+// setup (post World start).
+//
+//go:linkname Init runtime/goos.Hwinit1
+func Init() {
+	// initialize SoC (CPU, GPIO pinmux)
+	fsl91030.Init()
+
+	// initialize serial console
+	fsl91030.UART0.Init()
+}

--- a/board/nuclei/eval_soc/README.md
+++ b/board/nuclei/eval_soc/README.md
@@ -1,0 +1,128 @@
+TamaGo - bare metal Go - Nuclei EvalSoC support
+===============================================
+
+tamago | https://github.com/usbarmory/tamago
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+Marvin Drees
+marvin.drees@9elements.com
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The [eval_soc](https://github.com/usbarmory/tamago/tree/master/board/nuclei/eval_soc)
+package provides support for the Nuclei EvalSoC machine emulated by the
+[Nuclei QEMU](https://doc.nucleisys.com/nuclei_tools/qemu/index.html) fork
+(`-M nuclei_evalsoc`).
+
+The EvalSoC reuses the [Fisilink FSL91030](https://github.com/usbarmory/tamago/tree/master/soc/fisilink/fsl91030)
+SoC package (Nuclei UX600 core) and is closely related to the
+[MilkV Vega](https://github.com/usbarmory/tamago/tree/master/board/milkv/vega)
+board: both run the same UX600 core and SiFive-compatible peripherals. This
+package adapts the SoC to the emulator, which does not model the GPIO block or
+the hardware CLINT timer.
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For TamaGo see its [repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki) for information.
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| SoC      | Related board packages                                                         | Peripheral drivers                                                        |
+|----------|--------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| FSL91030 | [milkv/vega](https://github.com/usbarmory/tamago/tree/master/board/milkv/vega) | [UART, CLINT](https://github.com/usbarmory/tamago/tree/master/soc/sifive) |
+
+> [!WARNING]
+> This package targets the Nuclei QEMU emulator only; it is not meant for
+> physical hardware (see board/milkv/vega for the MilkV Vega board).
+
+Compilation
+===========
+
+The `linknanotime` build tag is required: it excludes the FSL91030 SoC timer
+(which reads the hardware CLINT, unmapped in the emulator) so this package can
+supply a time source based on the RISC-V `time` CSR.
+
+```bash
+# Set up TamaGo compiler
+export TAMAGO=/path/to/tamago-go/bin/go
+
+GOOS=tamago GOARCH=riscv64 GOOSPKG=github.com/usbarmory/tamago ${TAMAGO} build \
+    -tags linknanotime \
+    -ldflags "-T 0x41010000 -R 0x1000" \
+    -o example \
+    main.go
+```
+
+Always extract the ELF entry point and use it as the emulator jump target, as
+it differs from the `-T` text segment base:
+
+```bash
+ENTRY=$(riscv64-linux-gnu-readelf -h example | awk '/Entry point/{print $4}')
+```
+
+QEMU emulation
+==============
+
+Use the [Nuclei QEMU](https://doc.nucleisys.com/nuclei_tools/qemu/index.html)
+fork with the `nuclei_evalsoc` machine:
+
+```bash
+# Generate the machine configuration
+cat > fsl91030.json << EOF
+{
+    "general_config": {
+        "ddr":      { "base": "0x41000000", "size": "200M" },
+        "norflash": { "base": "0x20000000", "size": "64M" },
+        "uart0":    { "base": "0x10013000", "irq": "33" },
+        "uart1":    { "base": "0x10023000", "irq": "34" },
+        "iregion":  { "base": "0x4000000" },
+        "cpu_freq": "400000000",
+        "timer_freq": "32768",
+        "irqmax": "64"
+    },
+    "download": { "ddr": { "startaddr": "$ENTRY" } }
+}
+EOF
+
+# Run
+qemu-system-riscv64 \
+    -M nuclei_evalsoc,download=ddr,soc-cfg=fsl91030.json \
+    -cpu nuclei-ux600fd \
+    -m 200M -smp 1 -nodefaults -nographic \
+    -serial stdio \
+    -bios example
+```
+
+RAM is limited to 200 MB to avoid overlap with the emulator internal address
+decoding. Pass `startaddr` set to the ELF `e_entry`, not the `-T` base address.
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/board/nuclei/eval_soc/console.go
+++ b/board/nuclei/eval_soc/console.go
@@ -1,0 +1,22 @@
+// Nuclei EvalSoC emulator support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkprintk
+
+package eval_soc
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/fisilink/fsl91030"
+)
+
+//go:linkname printk runtime/goos.Printk
+func printk(c byte) {
+	fsl91030.UART0.Tx(c)
+}

--- a/board/nuclei/eval_soc/eval_soc.go
+++ b/board/nuclei/eval_soc/eval_soc.go
@@ -1,0 +1,47 @@
+// Nuclei EvalSoC emulator support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package eval_soc provides hardware initialization, automatically on import,
+// for the Nuclei EvalSoC machine emulated by the Nuclei QEMU fork
+// (qemu-system-riscv64 -M nuclei_evalsoc).
+//
+// The EvalSoC reuses the Fisilink FSL91030 SoC package (Nuclei UX600 core) and
+// is closely related to the MilkV Vega board (board/milkv/vega): both run the
+// same UX600 core and SiFive-compatible peripherals. This package adapts the
+// FSL91030 SoC to the emulator, which does not model the GPIO block or the
+// hardware CLINT timer, supplying a QEMU-compatible memory map and time source.
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=riscv64` as
+// supported by the TamaGo framework for bare metal Go on RISC-V SoCs, see
+// https://github.com/usbarmory/tamago.
+package eval_soc
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/fisilink/fsl91030"
+)
+
+// Peripheral instances
+var (
+	UART0 = fsl91030.UART0
+	UART1 = fsl91030.UART1
+)
+
+// Init takes care of the lower level initialization triggered early in runtime
+// setup (post World start).
+//
+//go:linkname Init runtime/goos.Hwinit1
+func Init() {
+	// initialize the RISC-V core; the emulator does not model the GPIO
+	// block, so UART pinmux (required only on real hardware) is skipped.
+	fsl91030.RV64.Init()
+
+	// initialize serial console
+	fsl91030.UART0.Init()
+}

--- a/board/nuclei/eval_soc/mem.go
+++ b/board/nuclei/eval_soc/mem.go
@@ -1,0 +1,24 @@
+// Nuclei EvalSoC emulator support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkramsize
+
+package eval_soc
+
+import (
+	_ "unsafe"
+)
+
+// The Nuclei QEMU nuclei_evalsoc machine limits usable RAM to 200 MB to avoid
+// an overlap with the emulator internal address decoding; the FSL91030 DRAM
+// base (0x41000000) is provided by the SoC package.
+//
+// Applications can override ramSize with the `linkramsize` build tag.
+
+//go:linkname ramSize runtime/goos.RamSize
+var ramSize uint64 = 0x0c800000 // 200 MB

--- a/board/nuclei/eval_soc/timer.go
+++ b/board/nuclei/eval_soc/timer.go
@@ -1,0 +1,40 @@
+// Nuclei EvalSoC emulator support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// The Nuclei QEMU nuclei_evalsoc machine does not model the FSL91030 hardware
+// CLINT timer, so the FSL91030 SoC nanotime (which reads it) must be excluded
+// with the `linknanotime` build tag and replaced by the implementation below,
+// which reads the standard RISC-V time CSR. Real UX600 hardware does not
+// implement the time CSR, hence this lives in the emulator board package.
+
+package eval_soc
+
+import (
+	_ "unsafe"
+)
+
+// TIMER_FREQ is the rate of the RISC-V time CSR as modeled by the Nuclei QEMU
+// nuclei_evalsoc machine (the `timer_freq` field of its SoC configuration).
+// It is independent of the real FSL91030 CLINT rate (fsl91030.RTCCLK).
+const TIMER_FREQ = 32768
+
+// defined in timer_riscv64.s
+func rdtime() uint64
+
+func mulDiv(x, m, d uint64) uint64 {
+	divx := x / d
+	modx := x - divx*d
+	divm := m / d
+	modm := m - divm*d
+	return divx*m + modx*divm + modx*modm/d
+}
+
+//go:linkname nanotime runtime/goos.Nanotime
+func nanotime() int64 {
+	return int64(mulDiv(rdtime(), 1e9, TIMER_FREQ))
+}

--- a/board/nuclei/eval_soc/timer_riscv64.s
+++ b/board/nuclei/eval_soc/timer_riscv64.s
@@ -1,0 +1,15 @@
+// Nuclei EvalSoC emulator support for tamago/riscv64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func rdtime() uint64
+TEXT ·rdtime(SB),NOSPLIT,$0-8
+	WORD	$0xc0102573	// rdtime a0 (csrr a0, time)
+	MOV	X10, ret+0(FP)
+	RET

--- a/riscv64/irq.go
+++ b/riscv64/irq.go
@@ -30,11 +30,21 @@ var (
 // defined in irq.s
 func irq_enable()
 func irq_disable()
+func meie_enable()
 func wfi()
 
 // EnableInterrupts unmasks IRQ interrupts.
 func (cpu *CPU) EnableInterrupts() {
 	irq_enable()
+}
+
+// EnableExternalInterrupts sets MIE.MEIE so that machine-level external
+// interrupts (PLIC sources) are delivered to this hart. Machine software
+// (MSIE) and timer (MTIE) interrupts are enabled elsewhere; the trap handler's
+// irq_disable does not clear MEIE, so a single call before [CPU.ServiceInterrupts]
+// suffices for applications that service PLIC interrupt sources.
+func (cpu *CPU) EnableExternalInterrupts() {
+	meie_enable()
 }
 
 // DisableInterrupts masks IRQ interrupts.

--- a/riscv64/irq.s
+++ b/riscv64/irq.s
@@ -21,6 +21,14 @@ TEXT ·irq_enable(SB),NOSPLIT|NOFRAME,$0
 
 	RET
 
+// func meie_enable()
+TEXT ·meie_enable(SB),NOSPLIT|NOFRAME,$0
+	// enable machine level external interrupts (PLIC sources)
+	MOV	$(1<<11), T0		// set MIE.MEIE
+	CSRRS	T0, MIE, ZERO
+
+	RET
+
 // func irq_disable()
 TEXT ·irq_disable(SB),NOSPLIT|NOFRAME,$0
 	// disable machine level software interrupts

--- a/riscv64/riscv64.go
+++ b/riscv64/riscv64.go
@@ -47,7 +47,7 @@ func exit(int32)
 func (cpu *CPU) DefaultIdleGovernor(pollUntil int64) {
 	// we have nothing to do forever
 	if pollUntil == math.MaxInt64 {
-		exit(0)
+		cpu.WaitInterrupt()
 	}
 }
 

--- a/soc/fisilink/fsl91030/README.md
+++ b/soc/fisilink/fsl91030/README.md
@@ -1,0 +1,69 @@
+TamaGo - bare metal Go - Fisilink FSL91030 support
+===================================================
+
+tamago | https://github.com/usbarmory/tamago
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+Marvin Drees
+marvin.drees@9elements.com
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The [fsl91030](https://github.com/usbarmory/tamago/tree/master/soc/fisilink/fsl91030)
+package provides support for the Fisilink FSL91030 SoC, a RV64IMAFDC processor
+based on the Nuclei UX600 core (sv39 MMU, 400 MHz).
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For TamaGo see its [repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki) for information.
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| SoC               | Related board packages                                                                                                                                                   | Peripheral drivers                                                        |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| Fisilink FSL91030 | [milkv/vega](https://github.com/usbarmory/tamago/tree/master/board/milkv/vega), [nuclei/eval_soc](https://github.com/usbarmory/tamago/tree/master/board/nuclei/eval_soc) | [CLINT, UART](https://github.com/usbarmory/tamago/tree/master/soc/sifive) |
+
+> [!WARNING]
+> This package is in early development stages and its API might still change.
+
+Build tags
+==========
+
+The following build tags allow applications to override the package own
+definition for the `runtime/goos` overlay:
+
+* `linkcpuinit`: include the `cpuinit` boot vector (`boot_riscv64.s`) which
+  initializes DDR, cache and the FPU before the runtime starts
+* `linknanotime`: exclude the default CLINT-based `nanotime`, allowing a board
+  package to supply its own time source
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/soc/fisilink/fsl91030/boot_riscv64.s
+++ b/soc/fisilink/fsl91030/boot_riscv64.s
@@ -1,0 +1,248 @@
+// Fisilink FSL91030 hardware boot initialization (linkcpuinit)
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+//
+// This file overrides the default riscv64 cpuinit when built with the
+// 'linkcpuinit' build tag, performing the hardware initialization (DDR,
+// cache, QSPI clock, FPU, stack) that a first-stage boot loader would
+// otherwise do. It suits loading the image directly into DRAM (e.g. via
+// JTAG); for NOR boot a relocating stage is required instead.
+//
+// The register offsets, the cache-enable value and the DDR controller
+// timing/configuration values are taken verbatim from the Nuclei freeloader.S
+// (Copyright Nuclei System Technologies) shipped with the FSL91030 vendor SDK.
+// The DDR timing values are opaque vendor-provided constants with no documented
+// bit-level meaning and are therefore reproduced as-is; the offsets they are
+// written to are named below for clarity.
+//
+// Sequence: disable cache, initialize DDR, configure the QSPI0 clock,
+// enable cache, disable interrupts and enable the FPU, set the stack to the
+// top of DRAM and jump to the runtime entry. No stack is available during
+// DDR init; register usage:
+//   X14 (A4): DDR controller base, constant
+//   X15 (A5): working register, DDR config values
+//   X12 (A2): 8192, used for multiple timing registers
+//   X13 (A3): derived timing value, reused for REG3
+//   X11 (A1): working register, more timing/config values
+
+//go:build linkcpuinit
+
+#include "textflag.h"
+
+// Nuclei vendor-specific machine cache control CSR (mcache_ctl, 0x7ca) is
+// unknown to the Go assembler, so accesses to it are WORD-encoded below:
+//   csrrs x0, 0x7ca, t0 = 0x7ca2a073
+//   csrrc x0, 0x7ca, t0 = 0x7ca2b073
+#define MCACHE_CTL_IC_EN 0  // bit 0:  instruction cache enable
+#define MCACHE_CTL_DC_EN 16 // bit 16: data cache enable
+
+// DDR controller (offsets relative to DDR_BASE)
+#define DDR_BASE          0x10019000
+#define DDR_STATUS        20  // status register
+#define DDR_STATUS_READY  1   // bit 1: controller ready
+#define DDR_MODE          512
+#define DDR_CTRL          516
+#define DDR_CTRL_INIT     0   // bit 0: trigger initialization
+#define DDR_CTRL_DONE     8   // bit 8: initialization done
+#define DDR_TIMING0       520
+#define DDR_TIMING1       524
+#define DDR_TIMING2       528
+#define DDR_TIMING3       532
+#define DDR_TIMING4       536
+#define DDR_TIMING5       540
+#define DDR_TIMING6       544
+#define DDR_TIMING7       548
+#define DDR_TIMING8       552
+#define DDR_TIMING9       556
+#define DDR_TIMINGA       560
+#define DDR_TIMINGB       564
+#define DDR_TIMINGC       568
+#define DDR_TIMINGD       572
+#define DDR_REG0          608
+#define DDR_REG1          624
+#define DDR_REG2          628
+#define DDR_REG3          632
+#define DDR_REG4          680
+#define DDR_REG5          684
+#define DDR_REG6          816
+#define DDR_REG7          824
+
+// QSPI0 controller
+#define QSPI0_BASE        0x10014000
+#define QSPI0_SCKDIV      100 // serial clock divider register (SCKDIV = 0x130009)
+
+// MSTATUS bits
+#define MSTATUS_LOW_MASK  0x7fff // MSTATUS[14:0]: interrupt-enable and FS bits
+#define MSTATUS_FS_INITIAL 13    // FS field low bit: 0b01 = Initial (FPU on)
+
+TEXT cpuinit(SB),NOSPLIT|NOFRAME,$0
+
+	// disable I/D cache before DDR init
+	MOV	$(1<<MCACHE_CTL_IC_EN | 1<<MCACHE_CTL_DC_EN), T0
+	WORD	$0x7ca2b073	// csrrc x0, CSR_MCACHE_CTL, t0
+
+	// DDR controller initialization
+	MOV	$DDR_BASE, X14
+
+	// clear DDR_STATUS, then wait for the controller-ready bit
+	MOVW	X0, DDR_STATUS(X14)
+ddr_wait_ready:
+	MOVW	DDR_STATUS(X14), X15
+	AND	$(1<<DDR_STATUS_READY), X15, X15
+	BEQ	X15, X0, ddr_wait_ready
+
+	// DDR_MODE: 134258688 + (-765) = 0x08009d03
+	MOV	$134258688, X15
+	ADDW	$-765, X15, X15
+	MOVW	X15, DDR_MODE(X14)
+
+	// DDR_CTRL: 0  (clear before triggering init)
+	MOVW	X0, DDR_CTRL(X14)
+
+	// DDR_TIMING0: 270336 + (-912)
+	MOV	$270336, X15
+	ADDW	$-912, X15, X15
+	MOVW	X15, DDR_TIMING0(X14)
+
+	// DDR_TIMING1: 24
+	MOV	$24, X15
+	MOVW	X15, DDR_TIMING1(X14)
+
+	// DDR_TIMING2: -2147483648 + 84
+	MOV	$-2147483648, X15
+	ADDW	$84, X15, X15
+	MOVW	X15, DDR_TIMING2(X14)
+
+	// DDR_TIMING3: 520556544 + (-1529)
+	MOV	$520556544, X15
+	ADDW	$-1529, X15, X15
+	MOVW	X15, DDR_TIMING3(X14)
+
+	// DDR_TIMING4: 289738752 + 530
+	// Also init X12 = 8192 here (used for TIMING5 and REG2)
+	MOV	$289738752, X15
+	MOV	$8192, X12
+	ADDW	$530, X15, X15
+	MOVW	X15, DDR_TIMING4(X14)
+
+	// DDR_TIMING5: X12 + 48 = 8240  -> stored in X13
+	ADDW	$48, X12, X13
+	MOVW	X13, DDR_TIMING5(X14)
+
+	// DDR_TIMING6: 28672 + (-254)  -> reuse X13
+	// X15 is overwritten here with 28672; X15 is later used for DDR_REG6
+	MOV	$28672, X15
+	ADDW	$-254, X15, X13
+	MOVW	X13, DDR_TIMING6(X14)
+
+	// DDR_TIMING7: 40960 + (-1639) -> X13 (saved for DDR_REG3)
+	MOV	$40960, X13
+	ADDW	$-1639, X13, X13
+	MOVW	X13, DDR_TIMING7(X14)
+
+	// DDR_TIMING8: 4096 + (-839)
+	MOV	$4096, X11
+	ADDW	$-839, X11, X11
+	MOVW	X11, DDR_TIMING8(X14)
+
+	// DDR_TIMING9: 0
+	MOVW	X0, DDR_TIMING9(X14)
+
+	// DDR_TIMINGA: -1879048192 + 4
+	MOV	$-1879048192, X11
+	ADDW	$4, X11, X11
+	MOVW	X11, DDR_TIMINGA(X14)
+
+	// DDR_TIMINGB: 50528256 + 771
+	MOV	$50528256, X11
+	ADDW	$771, X11, X11
+	MOVW	X11, DDR_TIMINGB(X14)
+
+	// DDR_TIMINGC: same value as TIMINGB
+	MOVW	X11, DDR_TIMINGC(X14)
+
+	// DDR_TIMINGD: 262144 + 19
+	MOV	$262144, X11
+	ADDW	$19, X11, X11
+	MOVW	X11, DDR_TIMINGD(X14)
+
+	// DDR_REG0: 8
+	MOV	$8, X11
+	MOVW	X11, DDR_REG0(X14)
+
+	// DDR_REG1: 255
+	MOV	$255, X11
+	MOVW	X11, DDR_REG1(X14)
+
+	// DDR_REG2: X12 + 546 = 8192 + 546 = 8738
+	ADDW	$546, X12, X12
+	MOVW	X12, DDR_REG2(X14)
+
+	// DDR_REG3: X13 (= DDR_TIMING7 value = 39321)
+	MOVW	X13, DDR_REG3(X14)
+
+	// DDR_REG4: 16384 + (-384)
+	MOV	$16384, X13
+	ADDW	$-384, X13, X13
+	MOVW	X13, DDR_REG4(X14)
+
+	// DDR_REG5: 401408 + (-1408)
+	MOV	$401408, X13
+	ADDW	$-1408, X13, X13
+	MOVW	X13, DDR_REG5(X14)
+
+	// DDR_REG6: X15 (= 28672) + 1911 = 30583
+	// X15 was set to 28672 at DDR_TIMING6 and not modified since
+	ADDW	$1911, X15, X15
+	MOVW	X15, DDR_REG6(X14)
+
+	// DDR_REG7: 5
+	MOV	$5, X15
+	MOVW	X15, DDR_REG7(X14)
+
+	// DDR_CTRL: 1 -> trigger DDR initialization
+	MOV	$(1<<DDR_CTRL_INIT), X15
+	MOVW	X15, DDR_CTRL(X14)
+
+	// trigger DDR init, then wait for the init-done bit
+	MOV	$(1<<DDR_CTRL_INIT), X15
+	MOVW	X15, DDR_CTRL(X14)
+	MOV	$DDR_BASE, X14
+ddr_wait_init:
+	MOVW	DDR_CTRL(X14), X15
+	AND	$(1<<DDR_CTRL_DONE), X15, X15
+	BEQ	X15, X0, ddr_wait_init
+
+	// configure the QSPI0 clock divider (SCKDIV = 0x130009)
+	MOV	$1245184, X15
+	MOV	$QSPI0_BASE, X14
+	ADDW	$9, X15, X15
+	MOVW	X15, QSPI0_SCKDIV(X14)
+
+	// enable I/D cache
+	MOV	$(1<<MCACHE_CTL_IC_EN | 1<<MCACHE_CTL_DC_EN), T0
+	WORD	$0x7ca2a073	// csrrs x0, CSR_MCACHE_CTL, t0
+
+	// disable interrupts and enable the FPU
+	MOV	$0, T0
+	CSRRW	T0, SIE, ZERO
+	CSRRW	T0, MIE, ZERO
+	// clear MSTATUS[14:0] (interrupt-enable and FS bits) ...
+	MOV	$MSTATUS_LOW_MASK, T0
+	CSRRC	T0, MSTATUS, ZERO
+	// ... then set FS = 0b01 (Initial) to enable the FPU
+	MOV	$(1<<MSTATUS_FS_INITIAL), T0
+	CSRRS	T0, MSTATUS, ZERO
+
+	// set the stack to the top of DRAM and jump to the runtime entry
+	MOV	runtime∕goos·RamStart(SB), X2
+	MOV	runtime∕goos·RamSize(SB), T1
+	MOV	runtime∕goos·RamStackOffset(SB), T2
+	ADD	T1, X2
+	SUB	T2, X2
+
+	JMP	_rt0_tamago_start(SB)

--- a/soc/fisilink/fsl91030/clock.go
+++ b/soc/fisilink/fsl91030/clock.go
@@ -1,0 +1,35 @@
+// Fisilink FSL91030 clock control
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package fsl91030
+
+// Clock frequencies for the FSL91030/Nuclei UX600.
+//
+// These are fixed hardware clocks; the vendor OpenSBI does not configure any
+// PLL (its frequency-measurement code is disabled and it simply assumes the
+// values below). The high-frequency clocks and the CPU clock are therefore
+// available from reset, with no runtime PLL reconfiguration interface.
+const (
+	// RTCCLK is the CLINT mtime tick rate, per the vendor device tree
+	// (nuclei-ux608.dts: timebase-frequency = 48828, i.e. HFCLK/4096).
+	RTCCLK   = 48828     // ~48.828 kHz - Timer/RTC clock frequency
+	HFCLK    = 200000000 // 200 MHz - High-frequency clock
+	HFCLK2   = 100000000 // 100 MHz - Secondary high-frequency clock
+	CPU_FREQ = 400000000 // 400 MHz - CPU frequency (nominal)
+
+	// UARTCLK is the UART baud-generator input clock. Confirmed against the
+	// vendor U-Boot, which programs UART0 (0x10013000) DIV = 0x364 (868) for
+	// a 115200 console: f_in = 115200 * (868 + 1) ~= 100 MHz (HFCLK2). The
+	// SiFive UART formula is baud = f_in / (div + 1).
+	UARTCLK = HFCLK2
+)
+
+// Freq returns the RISC-V core frequency.
+func Freq() uint32 {
+	return CPU_FREQ
+}

--- a/soc/fisilink/fsl91030/fsl91030.go
+++ b/soc/fisilink/fsl91030/fsl91030.go
@@ -1,0 +1,143 @@
+// Fisilink FSL91030 configuration and support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package fsl91030 provides support to Go bare metal unikernels written using
+// the TamaGo framework.
+//
+// The package implements initialization and drivers for the Fisilink FSL91030
+// System-on-Chip (SoC), a RV64IMAFDC processor based on the Nuclei UX600 core
+// with sv39 MMU, running at 400 MHz. Its peripherals are largely
+// SiFive-compatible (UART, GPIO, SPI).
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=riscv64` as
+// supported by the TamaGo framework for bare metal Go on RISC-V SoCs, see
+// https://github.com/usbarmory/tamago.
+package fsl91030
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/internal/reg"
+	"github.com/usbarmory/tamago/riscv64"
+	"github.com/usbarmory/tamago/soc/sifive/clint"
+	"github.com/usbarmory/tamago/soc/sifive/uart"
+)
+
+// Peripheral registers
+const (
+	// Nuclei timer; the CLINT-compatible mtime/mtimecmp interface sits at
+	// offset 0x1000 (mtime at 0x200cff8).
+	NUCLEI_TIMER_BASE = 0x2000000
+	CLINT_BASE        = NUCLEI_TIMER_BASE + 0x1000
+
+	// software reset key written to NUCLEI_TIMER_BASE+NUCLEI_TIMER_MSFTRST
+	NUCLEI_TIMER_MSFTRST     = 0xff0
+	NUCLEI_TIMER_MSFTRST_KEY = 0x80000a5f
+
+	// Platform-Level Interrupt Controller
+	PLIC_BASE = 0x8000000
+
+	// DDR controller
+	DDR_BASE = 0x10019000
+
+	// GPIO block; the Nuclei UX600 variant places the IOF (I/O Function)
+	// registers at offsets 0x44 (enable) and 0x48 (select).
+	GPIO_BASE    = 0x10011000
+	GPIO_IOF_EN  = GPIO_BASE + 0x44
+	GPIO_IOF_SEL = GPIO_BASE + 0x48
+
+	// UART0 (USB-C console) and UART1 (rear connector)
+	UART0_BASE = 0x10013000
+	UART1_BASE = 0x10012000
+
+	// QSPI0 NOR flash controller and its XIP window
+	QSPI0_BASE   = 0x10014000
+	NOR_XIP_BASE = 0x20000000
+	NOR_SIZE     = 64 * 1024 * 1024
+
+	// DRAM
+	DRAM_BASE = 0x41000000
+	DRAM_SIZE = 240 * 1024 * 1024
+
+	// Watchdog (Andes ATCWDT200)
+	WDT_BASE = 0x68000000
+)
+
+// Peripheral instances
+var (
+	// RISC-V core (RV64IMAFDC)
+	RV64 = &riscv64.CPU{
+		Counter: Counter,
+		// required before Init()
+		TimerMultiplier: 1,
+		TimerOffset:     1,
+	}
+
+	// Core-Local Interruptor (CLINT-compatible timer)
+	CLINT = &clint.CLINT{
+		Base:   CLINT_BASE,
+		RTCCLK: RTCCLK,
+	}
+
+	// UART0 (USB-C console)
+	UART0 = &uart.UART{
+		Index:    0,
+		Base:     UART0_BASE,
+		Clock:    uartClock,
+		Baudrate: uart.UART_DEFAULT_BAUDRATE,
+		Setup:    uart.UART_SETUP_8N1,
+	}
+
+	// UART1 (rear connector)
+	UART1 = &uart.UART{
+		Index:    1,
+		Base:     UART1_BASE,
+		Clock:    uartClock,
+		Baudrate: uart.UART_DEFAULT_BAUDRATE,
+		Setup:    uart.UART_SETUP_8N1,
+	}
+
+	// Watchdog timer (Andes ATCWDT200)
+	Watchdog = &WDT{Base: WDT_BASE}
+)
+
+// UART0 signals are routed to GPIO pin 16 (TX) and pin 17 (RX) via IOF0
+// connected to the onboard FTDI channel 0.
+const (
+	GPIO_UART0_TX = 16
+	GPIO_UART0_RX = 17
+)
+
+// uartClock returns the UART baud-generator input clock frequency.
+func uartClock() uint32 {
+	return UARTCLK
+}
+
+// InitUARTPinmux routes the UART0 signals to their physical pins by selecting
+// IOF0 (clearing the function select bit) and enabling the IOF override. Must
+// be called during board initialization before UART0 can be used.
+func InitUARTPinmux() {
+	reg.Clear(GPIO_IOF_SEL, GPIO_UART0_TX)
+	reg.Clear(GPIO_IOF_SEL, GPIO_UART0_RX)
+	reg.Set(GPIO_IOF_EN, GPIO_UART0_TX)
+	reg.Set(GPIO_IOF_EN, GPIO_UART0_RX)
+}
+
+// Model returns the SoC model name.
+func Model() string {
+	return "FSL91030"
+}
+
+// Reset resets the SoC by writing the software-reset key to the Nuclei timer
+// MSFTRST register (matching the vendor OpenSBI implementation).
+func Reset() {
+	reg.Write(NUCLEI_TIMER_BASE+NUCLEI_TIMER_MSFTRST, NUCLEI_TIMER_MSFTRST_KEY)
+
+	// wait for reset
+	select {}
+}

--- a/soc/fisilink/fsl91030/init.go
+++ b/soc/fisilink/fsl91030/init.go
@@ -1,0 +1,23 @@
+// Fisilink FSL91030 initialization
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package fsl91030
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname ramStackOffset runtime/goos.RamStackOffset
+var ramStackOffset uint64 = 0x100
+
+// Init takes care of the lower level initialization triggered early in runtime
+// setup (e.g. runtime/goos.Hwinit1).
+func Init() {
+	RV64.Init()
+	InitUARTPinmux()
+}

--- a/soc/fisilink/fsl91030/mem.go
+++ b/soc/fisilink/fsl91030/mem.go
@@ -1,0 +1,20 @@
+// Fisilink FSL91030 memory layout
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkramstart
+
+package fsl91030
+
+import (
+	_ "unsafe"
+)
+
+// FSL91030 DRAM is at 0x41000000 (240 MB).
+
+//go:linkname ramStart runtime/goos.RamStart
+var ramStart uint64 = 0x41000000

--- a/soc/fisilink/fsl91030/nanotime.go
+++ b/soc/fisilink/fsl91030/nanotime.go
@@ -1,0 +1,25 @@
+// Fisilink FSL91030 runtime nanotime hook
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// When built without the linknanotime tag this file provides the default
+// runtime/goos.Nanotime implementation, reading the CLINT mtime register.
+// Building with -tags linknanotime excludes it so a board package can supply
+// its own time source (see board/nuclei/eval_soc).
+//
+//go:build !linknanotime
+
+package fsl91030
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname nanotime runtime/goos.Nanotime
+func nanotime() int64 {
+	return RV64.GetTime()
+}

--- a/soc/fisilink/fsl91030/rng.go
+++ b/soc/fisilink/fsl91030/rng.go
@@ -1,0 +1,35 @@
+// Fisilink FSL91030 RNG initialization
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package fsl91030
+
+import (
+	"encoding/binary"
+	"time"
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/internal/rng"
+)
+
+//go:linkname initRNG runtime/goos.InitRNG
+func initRNG() {
+	drbg := &rng.DRBG{}
+	binary.LittleEndian.PutUint64(drbg.Seed[:], uint64(time.Now().UnixNano()))
+	rng.GetRandomDataFn = drbg.GetRandomData
+}
+
+// SetRNG allows to override the internal random number generator function used
+// by TamaGo on the FSL91030 SoC.
+//
+// At runtime initialization the fsl91030 package selects a timer seeded DRBG
+// as the FSL91030 lacks a (documented) hardware entropy source. This is
+// unsuitable for secure random number generation and must therefore be
+// overridden to ensure safe operation of Go `crypto/rand`.
+func SetRNG(getRandomData func([]byte)) {
+	rng.GetRandomDataFn = getRandomData
+}

--- a/soc/fisilink/fsl91030/timer.go
+++ b/soc/fisilink/fsl91030/timer.go
@@ -1,0 +1,16 @@
+// Fisilink FSL91030 timer support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package fsl91030
+
+// Counter returns the number of nanoseconds counted from the RTCCLK input.
+// It reads the hardware CLINT mtime register and is always available
+// regardless of the linknanotime build tag.
+func Counter() uint64 {
+	return uint64(CLINT.Nanotime())
+}

--- a/soc/fisilink/fsl91030/wdt.go
+++ b/soc/fisilink/fsl91030/wdt.go
@@ -1,0 +1,147 @@
+// Fisilink FSL91030 Watchdog Timer (Andes ATCWDT200)
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package fsl91030
+
+import (
+	"github.com/usbarmory/tamago/bits"
+	"github.com/usbarmory/tamago/internal/reg"
+)
+
+// Watchdog Timer register offsets (base address: 0x68000000).
+//
+// The FSL91030 integrates the Andes ATCWDT200 watchdog IP, which is also
+// used in VeriSilicon-based RISC-V SoCs.
+const (
+	WDT_IDREV   = 0x00 // ID and revision register (read-only)
+	WDT_CTRL    = 0x10 // Control register
+	WDT_RESTART = 0x14 // Restart register (write WDT_RESTART_KEY to feed)
+	WDT_WEN     = 0x18 // Write-enable register (write WDT_UNLOCK_KEY before any write)
+	WDT_ST      = 0x1c // Status register
+)
+
+// WDT control register bit fields.
+const (
+	WDT_CTRL_ENABLE       = 0 // Bit 0: watchdog enable
+	WDT_CTRL_CLKSEL       = 1 // Bit 1: clock select (0 = hfclk/512, 1 = hfclk/1)
+	WDT_CTRL_INTEN        = 2 // Bit 2: interrupt-before-reset enable
+	WDT_CTRL_RSTEN        = 3 // Bit 3: system-reset-on-timeout enable
+	WDT_CTRL_INTTIME      = 4 // Bits 4-6: interrupt timeout period (3-bit field)
+	WDT_CTRL_RSTTIME      = 8 // Bits 8-10: reset timeout period (3-bit field)
+	WDT_CTRL_INTTIME_MASK = 7 // 3-bit mask for INTTIME field
+	WDT_CTRL_RSTTIME_MASK = 7 // 3-bit mask for RSTTIME field
+)
+
+// WDT magic values.
+const (
+	// WDT_UNLOCK_KEY must be written to WDT_WEN before writing any other
+	// watchdog register. This write-protection mechanism prevents accidental
+	// modification of the watchdog configuration.
+	WDT_UNLOCK_KEY = 0x5aa55aa5
+
+	// WDT_RESTART_KEY must be written to WDT_RESTART to feed (kick) the
+	// watchdog and reset its counter, preventing a timeout.
+	WDT_RESTART_KEY = 0xcafecafe
+)
+
+// WDT timeout period codes for WDT_CTRL INTTIME/RSTTIME fields.
+// Each code N corresponds to a timeout of 2^(N+6) watchdog clock cycles.
+// With clksel=0 (hfclk/512 ≈ 390 kHz), the timeout periods are:
+//
+//	WDT_TO_6  = 2^6  / 390kHz ≈ 0.16 ms
+//	WDT_TO_8  = 2^8  / 390kHz ≈ 0.65 ms
+//	WDT_TO_10 = 2^10 / 390kHz ≈ 2.6 ms
+//	WDT_TO_12 = 2^12 / 390kHz ≈ 10.5 ms
+//	WDT_TO_14 = 2^14 / 390kHz ≈ 42 ms
+//	WDT_TO_17 = 2^17 / 390kHz ≈ 335 ms
+//	WDT_TO_19 = 2^19 / 390kHz ≈ 1.34 s
+//	WDT_TO_21 = 2^21 / 390kHz ≈ 5.4 s
+const (
+	WDT_TO_64K  = 0 // 2^6  clocks (~0.16 ms at hfclk/512)
+	WDT_TO_256K = 1 // 2^8  clocks (~0.65 ms)
+	WDT_TO_1M   = 2 // 2^10 clocks (~2.6 ms)
+	WDT_TO_4M   = 3 // 2^12 clocks (~10.5 ms)
+	WDT_TO_16M  = 4 // 2^14 clocks (~42 ms)
+	WDT_TO_128M = 5 // 2^17 clocks (~335 ms)
+	WDT_TO_512M = 6 // 2^19 clocks (~1.34 s)
+	WDT_TO_2G   = 7 // 2^21 clocks (~5.4 s)
+)
+
+// WDT represents the FSL91030 watchdog timer peripheral.
+type WDT struct {
+	// Base is the MMIO base address of the watchdog block (0x68000000).
+	Base uint32
+}
+
+// unlockAndWrite writes the write-enable key to WDT_WEN and then performs the
+// protected write to the given register in a single operation. The
+// write-protection re-engages automatically after each protected write, so the
+// unlock must immediately precede every write to WDT_CTRL or WDT_RESTART;
+// coupling the two here ensures the unlock can never be missed.
+func (w *WDT) unlockAndWrite(reg_off uint32, val uint32) {
+	reg.Write(w.Base+WDT_WEN, WDT_UNLOCK_KEY)
+	reg.Write(w.Base+reg_off, val)
+}
+
+// Revision returns the ATCWDT200 IP identification and revision word from
+// WDT_IDREV. This can be used to verify the peripheral is present and to
+// determine the silicon revision.
+func (w *WDT) Revision() uint32 {
+	return reg.Read(w.Base + WDT_IDREV)
+}
+
+// Start enables the watchdog with the specified interrupt and reset timeout
+// period codes (WDT_TO_* constants). A timeout first fires the interrupt
+// (if INTEN is set) and then resets the system.
+//
+// The RESTART key is written before CTRL so the counter starts from zero the
+// moment the watchdog is enabled, avoiding an early timeout from a stale count.
+func (w *WDT) Start(intTimeout, rstTimeout int) {
+	w.Stop()
+
+	var ctrl uint32
+	bits.Set(&ctrl, WDT_CTRL_ENABLE)
+	bits.Set(&ctrl, WDT_CTRL_RSTEN)
+	bits.Set(&ctrl, WDT_CTRL_INTEN)
+	bits.SetN(&ctrl, WDT_CTRL_INTTIME, WDT_CTRL_INTTIME_MASK, uint32(intTimeout))
+	bits.SetN(&ctrl, WDT_CTRL_RSTTIME, WDT_CTRL_RSTTIME_MASK, uint32(rstTimeout))
+
+	w.unlockAndWrite(WDT_RESTART, WDT_RESTART_KEY)
+	w.unlockAndWrite(WDT_CTRL, ctrl)
+}
+
+// Stop disables the watchdog by clearing the ENABLE bit in WDT_CTRL.
+func (w *WDT) Stop() {
+	ctrl := reg.Read(w.Base + WDT_CTRL)
+	bits.Clear(&ctrl, WDT_CTRL_ENABLE)
+	w.unlockAndWrite(WDT_CTRL, ctrl)
+}
+
+// Feed (kick) the watchdog by writing the restart key, resetting the counter
+// and preventing a timeout. Must be called periodically while the watchdog is
+// running (typically more frequently than the interrupt timeout period).
+func (w *WDT) Feed() {
+	w.unlockAndWrite(WDT_RESTART, WDT_RESTART_KEY)
+}
+
+// ForceReset triggers an immediate system reset via the watchdog. The watchdog
+// is configured with the shortest possible timeout and RSTEN enabled, then
+// started. The function does not return.
+func (w *WDT) ForceReset() {
+	// Configure minimum timeout (WDT_TO_64K) with reset enabled
+	w.Start(WDT_TO_64K, WDT_TO_64K)
+
+	// reset fires within ~0.16 ms
+	select {}
+}
+
+// Status returns the current value of WDT_ST (the status register). Bit 0
+// is set when the interrupt-timeout event has occurred.
+func (w *WDT) Status() uint32 {
+	return reg.Read(w.Base + WDT_ST)
+}

--- a/soc/sifive/uart/uart.go
+++ b/soc/sifive/uart/uart.go
@@ -39,6 +39,14 @@ const (
 	UARTx_TXCTRL = 0x0008
 	UARTx_RXCTRL = 0x000c
 	CTRL_EN      = 0
+
+	// baud rate divisor: fbaud = Clock / (div + 1)
+	UARTx_DIV = 0x0018
+
+	// Framing setup register (Nuclei UX600 variant only); the standard
+	// SiFive FU540 UART does not implement it. UART_SETUP_8N1 selects 8N1.
+	UARTx_SETUP    = 0x0020
+	UART_SETUP_8N1 = 0x30
 )
 
 // UART represents a serial port instance.
@@ -47,6 +55,17 @@ type UART struct {
 	Index int
 	// Base register
 	Base uint32
+	// Clock returns the UART input clock frequency in Hz; when set the baud
+	// rate divisor is programmed during Init (otherwise the divisor left by
+	// an earlier boot stage is kept).
+	Clock func() uint32
+	// Baudrate is the desired baud rate; defaults to UART_DEFAULT_BAUDRATE
+	// when zero. Only used when Clock is set.
+	Baudrate uint32
+	// Setup, when non-zero, is written to the framing setup register
+	// (offset 0x20) during Init. Required by the Nuclei UX600 UART variant
+	// (UART_SETUP_8N1); leave zero for standard SiFive FU540 UARTs.
+	Setup uint32
 
 	// control registers
 	txdata uint32
@@ -62,6 +81,23 @@ func (hw *UART) Init() {
 
 	hw.txdata = hw.Base + UARTx_TXDATA
 	hw.rxdata = hw.Base + UARTx_RXDATA
+
+	if hw.Clock != nil {
+		baudrate := hw.Baudrate
+
+		if baudrate == 0 {
+			baudrate = UART_DEFAULT_BAUDRATE
+		}
+
+		// div = ceil(f_in / baud) - 1 (SiFive FSBL convention, matching
+		// the vendor OpenSBI and U-Boot drivers).
+		clock := hw.Clock()
+		reg.Write(hw.Base+UARTx_DIV, (clock+baudrate-1)/baudrate-1)
+	}
+
+	if hw.Setup != 0 {
+		reg.Write(hw.Base+UARTx_SETUP, hw.Setup)
+	}
 
 	reg.Set(hw.Base+UARTx_TXCTRL, CTRL_EN)
 	reg.Set(hw.Base+UARTx_RXCTRL, CTRL_EN)


### PR DESCRIPTION
This adds another RISCV64 target namely the MilkV Vega and its SoC. There have been a bunch of resources been uploaded to the milkv-vega GitHub org including the datasheets and reference code namely freeloader (small assembly program at the reset vector, OpenSBI, u-boot and Linux). Some other SoC control like items used to configure the switch fabric are largely done in a closed source userspace binary but all the register definitions are available from the datasheets. This PR remains in draft until everything has been validated to work correctly on hardware and scope of the port has been fully clarified.

NOTE: The original PCB only comes with 4MByte flash, I upgraded mine to 64MByte flash. Tamago does fit into 4MByte but in order to make more use of the platform I changed the flash size.