### PR TITLE
Return correct byte count from sifive and nxp uart Read/Write

### DIFF
--- a/soc/nxp/uart/uart.go
+++ b/soc/nxp/uart/uart.go
@@ -304,19 +304,19 @@ func (hw *UART) Rx() (c byte, valid bool) {
 }
 
 // Write data from buffer to serial port.
-func (hw *UART) Write(buf []byte) (n int, _ error) {
-	for n = range buf {
-		hw.Tx(buf[n])
+func (hw *UART) Write(buf []byte) (int, error) {
+	for _, c := range buf {
+		hw.Tx(c)
 	}
 
-	return
+	return len(buf), nil
 }
 
 // Read available data to buffer from serial port.
 func (hw *UART) Read(buf []byte) (n int, _ error) {
 	var valid bool
 
-	for n = range buf {
+	for n < len(buf) {
 		buf[n], valid = hw.Rx()
 
 		if !valid {
@@ -326,6 +326,8 @@ func (hw *UART) Read(buf []byte) (n int, _ error) {
 
 			break
 		}
+
+		n++
 	}
 
 	return

--- a/soc/sifive/uart/uart.go
+++ b/soc/sifive/uart/uart.go
@@ -88,19 +88,19 @@ func (hw *UART) Rx() (c byte, valid bool) {
 }
 
 // Write data from buffer to serial port.
-func (hw *UART) Write(buf []byte) (n int, _ error) {
-	for n = range buf {
-		hw.Tx(buf[n])
+func (hw *UART) Write(buf []byte) (int, error) {
+	for _, c := range buf {
+		hw.Tx(c)
 	}
 
-	return
+	return len(buf), nil
 }
 
 // Read available data to buffer from serial port.
 func (hw *UART) Read(buf []byte) (n int, _ error) {
 	var valid bool
 
-	for n = range buf {
+	for n < len(buf) {
 		buf[n], valid = hw.Rx()
 
 		if !valid {
@@ -110,6 +110,8 @@ func (hw *UART) Read(buf []byte) (n int, _ error) {
 
 			break
 		}
+
+		n++
 	}
 
 	return


### PR DESCRIPTION
There was an off-by-one error in two uart drivers. I noticed this while working on #67 as that platform uses the SiFive UART IP. While fixing this the LLM used to assist debugging noticed a similar issue with the NXP driver.