### PR TITLE
add tamago/loong64 support, QEMU virt target

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Introduction
 ============
 
 TamaGo is a framework that enables compilation and execution of unencumbered Go
-applications on bare metal processors (AMD64, ARM, ARM64, RISCV64).
+applications on bare metal processors (AMD64, ARM, ARM64, RISCV64, LOONG64).
 
 The projects spawns from the desire of reducing the attack surface of embedded
 systems firmware by removing any runtime dependency on C code and Operating
@@ -119,6 +119,16 @@ The following table summarizes currently supported RISC-V SoCs and boards
 | Fisilink FSL91030   | [Nuclei QEMU](https://doc.nucleisys.com/nuclei_tools/qemu/index.html)         | [fsl91030](https://github.com/usbarmory/tamago/tree/master/soc/fisilink/fsl91030) | [eval_soc](https://github.com/usbarmory/tamago/tree/master/board/nuclei/eval_soc)        |
 | SiFive FU540        | [QEMU sifive_u](https://www.qemu.org/docs/master/system/riscv/sifive_u.html)  | [fu540](https://github.com/usbarmory/tamago/tree/master/soc/sifive/fu540)         | [qemu/sifive_u](https://github.com/usbarmory/tamago/tree/master/board/qemu/sifive_u)     |
 
+Supported LoongArch targets
+===========================
+
+The following table summarizes currently supported LoongArch SoCs and boards
+(`GOOS=tamago GOARCH=loong64`).
+
+| SoC             | Board                                                                    | SoC package                                                                       | Board package                                                                |
+|-----------------|--------------------------------------------------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| Loongson 3A5000 | [QEMU virt](https://www.qemu.org/docs/master/system/loongarch/virt.html) | [ls3a5000](https://github.com/usbarmory/tamago/tree/master/soc/loongson/ls3a5000) | [qemu/virt](https://github.com/usbarmory/tamago/tree/master/board/qemu/virt) |
+
 Userspace targets
 =================
 
@@ -222,6 +232,9 @@ GOOS=tamago GOARCH=riscv64 ${TAMAGO} build -ldflags "-T 0x80010000 -R 0x1000" ma
 
 # Example for AI Foundry Erbium
 GOOS=tamago GOARCH=riscv64 GOSOFT=1 ${TAMAGO} build -ldflags "-T 0x40010000 -R 0x1000" main.go
+
+# Example for QEMU LoongArch virt
+GOOS=tamago GOARCH=loong64 ${TAMAGO} build -ldflags "-T 0x1000000 -R 0x1000" main.go
 
 # Example for Linux userspace
 GOOS=tamago ${TAMAGO} build main.go

--- a/board/qemu/virt/README.md
+++ b/board/qemu/virt/README.md
@@ -1,0 +1,117 @@
+TamaGo - bare metal Go - QEMU virt support
+==========================================
+
+tamago | https://github.com/usbarmory/tamago  
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.  
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+tannevaled  
+https://github.com/tannevaled  
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The `virt` package provides support for the QEMU `virt` machine, currently
+targeting [LoongArch](https://www.qemu.org/docs/master/system/loongarch/virt.html)
+(`GOARCH=loong64`) configured with a single core.
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For more information about TamaGo see its
+[repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki).
+
+For the underlying driver support for this board see package
+[ls3a5000](https://github.com/usbarmory/tamago/tree/master/soc/loongson/ls3a5000).
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| SoC               | Board                                                                          | SoC package                                                                        | Board package                                                                |
+|-------------------|--------------------------------------------------------------------------------|------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| Loongson 3A5000   | [QEMU virt](https://www.qemu.org/docs/master/system/loongarch/virt.html)       | [ls3a5000](https://github.com/usbarmory/tamago/tree/master/soc/loongson/ls3a5000)  | [qemu/virt](https://github.com/usbarmory/tamago/tree/master/board/qemu/virt) |
+
+Compiling
+=========
+
+Go applications are required to set `GOOSPKG` to the desired
+[runtime/goos](https://github.com/usbarmory/tamago-go/tree/latest/src/runtime/goos)
+overlay and import the relevant board package to ensure that hardware
+initialization and runtime support take place:
+
+```golang
+import (
+	_ "github.com/usbarmory/tamago/board/qemu/virt"
+)
+```
+
+Go applications can be compiled as usual, using the compiler built for the
+TamaGo framework, but with the addition of the following flags/variables:
+
+```sh
+GOOS=tamago GOOSPKG=github.com/usbarmory/tamago GOARCH=loong64 \
+	${TAMAGO} build -ldflags "-T 0x1000000 -R 0x1000" main.go
+```
+
+The QEMU `virt` machine reserves the low 2 MiB of RAM for boot information and
+the device tree, therefore the text segment must be linked above that region
+(the example above links at 16 MiB).
+
+Build tags
+==========
+
+The following build tags allow applications to override the package own
+definition for the `runtime/goos` overlay:
+
+* `linkramsize`: exclude `ramSize` from `mem.go`
+* `linkprintk`: exclude `printk` from `console.go`
+
+Executing and debugging
+=======================
+
+The target can be executed under emulation as follows:
+
+```sh
+qemu-system-loongarch64 \
+	-machine virt -m 256M \
+	-nographic -monitor none -serial stdio -net none \
+	-kernel main
+```
+
+Unlike the riscv64 `qemu` targets no BIOS is required, as the QEMU LoongArch
+`virt` machine loads the ELF image and jumps to its entry point directly.
+
+The emulated target can be debugged with GDB by adding the `-S -s` flags to the
+previous execution command, this will make qemu wait for a GDB connection that
+can be launched as follows:
+
+```sh
+loongarch64-unknown-linux-gnu-gdb -ex "target remote 127.0.0.1:1234" main
+```
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago  
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/board/qemu/virt/console_loong64.go
+++ b/board/qemu/virt/console_loong64.go
@@ -1,0 +1,22 @@
+// QEMU LoongArch virt support for tamago/loong64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkprintk
+
+package virt
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/loongson/ls3a5000"
+)
+
+//go:linkname printk runtime/goos.Printk
+func printk(c byte) {
+	ls3a5000.UART0.Tx(c)
+}

--- a/board/qemu/virt/mem.go
+++ b/board/qemu/virt/mem.go
@@ -1,0 +1,20 @@
+// QEMU virt support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkramsize
+
+package virt
+
+import (
+	_ "unsafe"
+)
+
+// Applications can override ramSize with the `linkramsize` build tag.
+//
+//go:linkname ramSize runtime/goos.RamSize
+var ramSize uint64 = 0x10000000 // 256MB

--- a/board/qemu/virt/virt_loong64.go
+++ b/board/qemu/virt/virt_loong64.go
@@ -1,0 +1,38 @@
+// QEMU LoongArch virt support for tamago/loong64
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package virt provides hardware initialization, automatically on import, for
+// the QEMU LoongArch `virt` machine.
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=loong64` as
+// supported by the TamaGo framework for bare metal Go on LoongArch SoCs, see
+// https://github.com/usbarmory/tamago.
+package virt
+
+import (
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/soc/loongson/ls3a5000"
+)
+
+// Peripheral instances
+var (
+	UART0 = ls3a5000.UART0
+)
+
+// Init takes care of the lower level initialization triggered early in runtime
+// setup (post World start).
+//
+//go:linkname Init runtime/goos.Hwinit1
+func Init() {
+	// initialize SoC
+	ls3a5000.Init()
+
+	// initialize serial console
+	ls3a5000.UART0.Init()
+}

--- a/goos/goos_loong64.s
+++ b/goos/goos_loong64.s
@@ -1,0 +1,12 @@
+// Custom GOOS support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+TEXT ·CPUInit(SB),NOSPLIT|NOFRAME,$0
+	JMP	cpuinit(SB)

--- a/internal/reg/reg_loong64.s
+++ b/internal/reg/reg_loong64.s
@@ -1,0 +1,55 @@
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// func Move(dst uint32, src uint32)
+TEXT ·Move(SB),$0-8
+	MOVWU	dst+0(FP), R4
+	MOVWU	src+4(FP), R5
+
+	// copy src to dst
+	MOVWU	(R5), R6
+	MOVWU	R6, (R4)
+
+	// zero out src
+	MOVWU	R0, (R5)
+
+	RET
+
+// func Read8(addr uint32) uint8
+TEXT ·Read8(SB),$0-9
+	MOVWU	addr+0(FP), R4
+	MOVBU	(R4), R5
+	MOVB	R5, ret+8(FP)
+
+	RET
+
+// func Write8(addr uint32, val uint8)
+TEXT ·Write8(SB),$0-5
+	MOVWU	addr+0(FP), R4
+	MOVBU	val+4(FP), R5
+
+	MOVB	R5, (R4)
+
+	RET
+
+// func Write(addr uint32, val uint32)
+TEXT ·Write(SB),$0-8
+	MOVWU	addr+0(FP), R4
+	MOVWU	val+4(FP), R5
+
+	MOVWU	R5, (R4)
+
+	RET
+
+// func Write64(addr uint64, val uint64)
+TEXT ·Write64(SB),$0-16
+	MOVV	addr+0(FP), R4
+	MOVV	val+8(FP), R5
+
+	MOVV	R5, (R4)
+
+	RET

--- a/loong64/README.md
+++ b/loong64/README.md
@@ -1,0 +1,67 @@
+TamaGo - bare metal Go - LoongArch 64-bit support
+=================================================
+
+tamago | https://github.com/usbarmory/tamago  
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.  
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+tannevaled  
+https://github.com/tannevaled  
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The [loong64](https://github.com/usbarmory/tamago/tree/master/loong64) package
+provides support for LoongArch 64-bit CPUs.
+
+The CPU runs in Direct Address translation mode (`CRMD.DA`), therefore no page
+tables are required; the Go LoongArch assembler exposes no privileged CSR, TLB,
+`ertn` or `idle` mnemonics, so these are emitted as hand-encoded `WORD`
+directives (verified with `go tool objdump`).
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For TamaGo see its [repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki) for information.
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| CPU     | Related platform packages                                                 | Core drivers                |
+|---------|---------------------------------------------------------------------------|-----------------------------|
+| la464   | [qemu/virt](https://github.com/usbarmory/tamago/blob/master/board/qemu/virt) | stable timer, CPUCFG, exceptions, interrupts |
+
+Build tags
+==========
+
+The following build tags allow applications to override the package own
+definition for the `runtime/goos` overlay:
+
+* `linkcpuinit`: exclude `cpuinit` from `init.s`
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago  
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/loong64/csr.go
+++ b/loong64/csr.go
@@ -1,0 +1,22 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+// Control and Status Register accessors, defined in csr.s.
+func read_crmd() uint64
+func write_crmd(val uint64)
+func read_ecfg() uint64
+func write_ecfg(val uint64)
+func read_estat() uint64
+func read_era() uint64
+func read_badv() uint64
+func set_eentry(addr uint64)
+func read_cpuid() uint64
+func write_tcfg(val uint64)
+func write_ticlr(val uint64)

--- a/loong64/csr.s
+++ b/loong64/csr.s
@@ -1,0 +1,84 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// The Go LoongArch assembler provides no CSR access mnemonics, therefore these
+// helpers are emitted as hand-encoded WORD directives, verified via
+// `go tool objdump`:
+//
+//	csrrd R4, csr = 0x04000000 | (csr<<10) | 0x04
+//	csrwr R4, csr = 0x04000000 | (csr<<10) | 0x24
+//
+// CSR numbers: CRMD=0x0, ECFG=0x4, ESTAT=0x5, ERA=0x6, BADV=0x7, EENTRY=0xc.
+
+// func read_crmd() uint64
+TEXT ·read_crmd(SB),NOSPLIT,$0-8
+	WORD	$0x04000004	// csrrd R4, CRMD
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func write_crmd(val uint64)
+TEXT ·write_crmd(SB),NOSPLIT,$0-8
+	MOVV	val+0(FP), R4
+	WORD	$0x04000024	// csrwr R4, CRMD
+	RET
+
+// func read_ecfg() uint64
+TEXT ·read_ecfg(SB),NOSPLIT,$0-8
+	WORD	$0x04001004	// csrrd R4, ECFG
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func write_ecfg(val uint64)
+TEXT ·write_ecfg(SB),NOSPLIT,$0-8
+	MOVV	val+0(FP), R4
+	WORD	$0x04001024	// csrwr R4, ECFG
+	RET
+
+// func read_estat() uint64
+TEXT ·read_estat(SB),NOSPLIT,$0-8
+	WORD	$0x04001404	// csrrd R4, ESTAT
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func read_era() uint64
+TEXT ·read_era(SB),NOSPLIT,$0-8
+	WORD	$0x04001804	// csrrd R4, ERA
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func read_badv() uint64
+TEXT ·read_badv(SB),NOSPLIT,$0-8
+	WORD	$0x04001c04	// csrrd R4, BADV
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func set_eentry(addr uint64)
+TEXT ·set_eentry(SB),NOSPLIT,$0-8
+	MOVV	addr+0(FP), R4
+	WORD	$0x04003024	// csrwr R4, EENTRY
+	RET
+
+// func read_cpuid() uint64
+TEXT ·read_cpuid(SB),NOSPLIT,$0-8
+	WORD	$0x04008004	// csrrd R4, CPUID(0x20)
+	MOVV	R4, ret+0(FP)
+	RET
+
+// func write_tcfg(val uint64)
+TEXT ·write_tcfg(SB),NOSPLIT,$0-8
+	MOVV	val+0(FP), R4
+	WORD	$0x04010424	// csrwr R4, TCFG(0x41)
+	RET
+
+// func write_ticlr(val uint64)
+TEXT ·write_ticlr(SB),NOSPLIT,$0-8
+	MOVV	val+0(FP), R4
+	WORD	$0x04011024	// csrwr R4, TICLR(0x44)
+	RET

--- a/loong64/exception.go
+++ b/loong64/exception.go
@@ -1,0 +1,83 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+import (
+	"unsafe"
+
+	"github.com/usbarmory/tamago/internal/exception"
+)
+
+// LoongArch exception codes (ESTAT.Ecode), see the LoongArch Reference Manual
+// Volume 1, Table of Exceptions.
+const (
+	INT = 0x0  // interrupt
+	PIL = 0x1  // page invalid, load
+	PIS = 0x2  // page invalid, store
+	PIF = 0x3  // page invalid, fetch
+	PME = 0x4  // page modification
+	PNR = 0x5  // page not readable
+	PNX = 0x6  // page not executable
+	PPI = 0x7  // page privilege violation
+	ADE = 0x8  // address error
+	ALE = 0x9  // address alignment error
+	BCE = 0xa  // bound check error
+	SYS = 0xb  // system call
+	BRK = 0xc  // breakpoint
+	INE = 0xd  // instruction non-existent
+	IPE = 0xe  // instruction privilege error
+	FPD = 0xf  // floating point disabled
+	FPE = 0x12 // floating point error
+)
+
+// defined in exception.s
+func trapHandler()
+
+// ExceptionHandler represents an exception handler function.
+type ExceptionHandler func()
+
+func vector(fn ExceptionHandler) uint64 {
+	return **((**uint64)(unsafe.Pointer(&fn)))
+}
+
+// DefaultExceptionHandler handles an exception by printing the exception cause,
+// return address and bad virtual address before panicking.
+func DefaultExceptionHandler() {
+	estat := read_estat()
+
+	ecode := int(estat>>16) & 0x3f
+	esubcode := int(estat>>22) & 0x1ff
+	is := int(estat) & 0x1fff
+
+	print("loong64 exception: ecode ", ecode, " esubcode ", esubcode, " is ", is, " badv ", int(read_badv()), "\n")
+	exception.Throw(uintptr(read_era()))
+}
+
+// SystemExceptionHandler allows to override the default exception handler.
+var SystemExceptionHandler = DefaultExceptionHandler
+
+func systemException() {
+	SystemExceptionHandler()
+}
+
+// SetExceptionHandler updates the CPU exception entry with the address of the
+// argument function.
+func (cpu *CPU) SetExceptionHandler(fn ExceptionHandler) {
+	set_eentry(vector(fn))
+}
+
+// GetExceptionHandlerAddress returns the CPU exception entry address.
+func (cpu *CPU) GetExceptionHandlerAddress() uint64 {
+	return vector(trapHandler)
+}
+
+// SetExceptionHandlerAddress updates the CPU exception entry address.
+func (cpu *CPU) SetExceptionHandlerAddress(addr uint64) {
+	set_eentry(addr)
+}

--- a/loong64/exception.s
+++ b/loong64/exception.s
@@ -1,0 +1,121 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The Go LoongArch assembler provides no CSR access, exception return (ertn) or
+// idle mnemonics, therefore these are emitted as hand-encoded WORD directives,
+// verified via `go tool objdump`:
+//
+//	csrrd  R4, csr  = 0x04000000 | (csr<<10) | 0x04
+//	csrwr  R4, csr  = 0x04000000 | (csr<<10) | 0x24
+//	ertn            = 0x06483800
+//
+// CSR numbers: PRMD=0x1, ESTAT=0x5, SAVE0=0x30.
+
+// trapHandler is the common exception entry (ECFG.VS = 0); all exceptions and
+// interrupts share this single vector and are dispatched in software on the
+// ESTAT.Ecode field (0 identifies an interrupt).
+TEXT ·trapHandler(SB),NOSPLIT|NOFRAME,$0
+	WORD	$0x0400c024		// csrwr R4, SAVE0 (stash R4)
+	WORD	$0x04001404		// csrrd R4, ESTAT
+	SRLV	$16, R4, R4
+	AND	$0x3f, R4, R4		// R4 = ESTAT.Ecode
+	BNE	R4, R0, exception
+
+	// interrupt
+	WORD	$0x0400c004		// csrrd R4, SAVE0 (restore R4)
+	JMP	·handleInterrupt(SB)
+
+exception:
+	WORD	$0x0400c004		// csrrd R4, SAVE0 (restore R4)
+	JMP	·systemException(SB)
+
+// handleInterrupt relays the interrupt to the os/signal subsystem and returns
+// to the interrupted context with interrupts left masked (PRMD.PIE cleared), so
+// the servicing goroutine is responsible for clearing the source and unmasking.
+TEXT ·handleInterrupt(SB),NOSPLIT|NOFRAME,$0
+	// save caller registers (R0 is zero, R3 is SP)
+	MOVV	R1, -1*8(R3)
+	MOVV	R2, -2*8(R3)
+	MOVV	R4, -3*8(R3)
+	MOVV	R5, -4*8(R3)
+	MOVV	R6, -5*8(R3)
+	MOVV	R7, -6*8(R3)
+	MOVV	R8, -7*8(R3)
+	MOVV	R9, -8*8(R3)
+	MOVV	R10, -9*8(R3)
+	MOVV	R11, -10*8(R3)
+	MOVV	R12, -11*8(R3)
+	MOVV	R13, -12*8(R3)
+	MOVV	R14, -13*8(R3)
+	MOVV	R15, -14*8(R3)
+	MOVV	R16, -15*8(R3)
+	MOVV	R17, -16*8(R3)
+	MOVV	R18, -17*8(R3)
+	MOVV	R19, -18*8(R3)
+	MOVV	R20, -19*8(R3)
+	MOVV	R21, -20*8(R3)
+	MOVV	g,   -21*8(R3)
+	MOVV	R23, -22*8(R3)
+	MOVV	R24, -23*8(R3)
+	MOVV	R25, -24*8(R3)
+	MOVV	R26, -25*8(R3)
+	MOVV	R27, -26*8(R3)
+	MOVV	R28, -27*8(R3)
+	MOVV	R29, -28*8(R3)
+	MOVV	R30, -29*8(R3)
+	MOVV	R31, -30*8(R3)
+
+	ADDVU	$(-32*8), R3, R3
+	MOVV	$(const_IRQ_SIGNAL), R4
+	MOVV	R4, 8(R3)
+	CALL	os∕signal·Relay(SB)
+	ADDVU	$(32*8), R3, R3
+
+	// keep interrupts masked on return: clear PRMD.PIE (bit 2)
+	WORD	$0x04000404		// csrrd R4, PRMD
+	MOVV	$4, R5
+	ANDN	R5, R4, R4
+	WORD	$0x04000424		// csrwr R4, PRMD
+
+	// restore caller registers
+	MOVV	-1*8(R3), R1
+	MOVV	-2*8(R3), R2
+	MOVV	-3*8(R3), R4
+	MOVV	-4*8(R3), R5
+	MOVV	-5*8(R3), R6
+	MOVV	-6*8(R3), R7
+	MOVV	-7*8(R3), R8
+	MOVV	-8*8(R3), R9
+	MOVV	-9*8(R3), R10
+	MOVV	-10*8(R3), R11
+	MOVV	-11*8(R3), R12
+	MOVV	-12*8(R3), R13
+	MOVV	-13*8(R3), R14
+	MOVV	-14*8(R3), R15
+	MOVV	-15*8(R3), R16
+	MOVV	-16*8(R3), R17
+	MOVV	-17*8(R3), R18
+	MOVV	-18*8(R3), R19
+	MOVV	-19*8(R3), R20
+	MOVV	-20*8(R3), R21
+	MOVV	-21*8(R3), g
+	MOVV	-22*8(R3), R23
+	MOVV	-23*8(R3), R24
+	MOVV	-24*8(R3), R25
+	MOVV	-25*8(R3), R26
+	MOVV	-26*8(R3), R27
+	MOVV	-27*8(R3), R28
+	MOVV	-28*8(R3), R29
+	MOVV	-29*8(R3), R30
+	MOVV	-30*8(R3), R31
+
+	// exception return
+	WORD	$0x06483800		// ertn

--- a/loong64/features.go
+++ b/loong64/features.go
@@ -1,0 +1,53 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+// CPUCFG word 2 feature bits.
+const (
+	cpucfg2FP     = 1 << 0  // basic floating point
+	cpucfg2FPSP   = 1 << 1  // single precision floating point
+	cpucfg2FPDP   = 1 << 2  // double precision floating point
+	cpucfg2LSX    = 1 << 6  // 128-bit vector extension
+	cpucfg2LASX   = 1 << 7  // 256-bit vector extension
+	cpucfg2Crypto = 1 << 9  // cryptography extension
+	cpucfg2LVZ    = 1 << 10 // virtualization extension
+)
+
+// Features represents the processor capabilities as reported by CPUCFG.
+type Features struct {
+	// FP indicates basic floating point support.
+	FP bool
+	// FPSP indicates single precision floating point support.
+	FPSP bool
+	// FPDP indicates double precision floating point support.
+	FPDP bool
+	// LSX indicates 128-bit vector (LSX) support.
+	LSX bool
+	// LASX indicates 256-bit vector (LASX) support.
+	LASX bool
+	// Crypto indicates cryptography acceleration support.
+	Crypto bool
+	// LVZ indicates hardware virtualization support.
+	LVZ bool
+}
+
+// Features returns the processor capabilities.
+func (cpu *CPU) Features() (features Features) {
+	w2 := read_cpucfg(0x2)
+
+	features.FP = w2&cpucfg2FP != 0
+	features.FPSP = w2&cpucfg2FPSP != 0
+	features.FPDP = w2&cpucfg2FPDP != 0
+	features.LSX = w2&cpucfg2LSX != 0
+	features.LASX = w2&cpucfg2LASX != 0
+	features.Crypto = w2&cpucfg2Crypto != 0
+	features.LVZ = w2&cpucfg2LVZ != 0
+
+	return
+}

--- a/loong64/init.go
+++ b/loong64/init.go
@@ -1,0 +1,19 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+import (
+	_ "unsafe"
+)
+
+// Init takes care of the lower level initialization triggered before runtime
+// setup (pre World start).
+//
+//go:linkname Init runtime/goos.Hwinit0
+func Init() {}

--- a/loong64/init.s
+++ b/loong64/init.s
@@ -1,0 +1,14 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+//go:build !linkcpuinit
+
+#include "textflag.h"
+
+TEXT cpuinit(SB),NOSPLIT|NOFRAME,$0
+	JMP	github·com∕usbarmory∕tamago∕loong64·Init(SB)

--- a/loong64/irq.go
+++ b/loong64/irq.go
@@ -1,0 +1,82 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// IRQ_SIGNAL represents the `os/signal` used to signal and service interrupts.
+const IRQ_SIGNAL = syscall.SIGTRAP
+
+// CRMD.IE global interrupt enable bit.
+const crmdIE = 1 << 2
+
+// defined in irq.s
+func idle()
+
+// defined in exception.s
+func handleInterrupt()
+
+// EnableInterrupts unmasks IRQ interrupts globally by setting CRMD.IE.
+func (cpu *CPU) EnableInterrupts() {
+	write_crmd(read_crmd() | crmdIE)
+}
+
+// DisableInterrupts masks IRQ interrupts globally by clearing CRMD.IE.
+func (cpu *CPU) DisableInterrupts() {
+	write_crmd(read_crmd() &^ crmdIE)
+}
+
+// EnableInterrupt unmasks the argument local interrupt line in ECFG.LIE, the
+// line index follows the ESTAT.IS layout (e.g. 11 for the timer interrupt).
+func (cpu *CPU) EnableInterrupt(index int) {
+	write_ecfg(read_ecfg() | (1 << index))
+}
+
+// DisableInterrupt masks the argument local interrupt line in ECFG.LIE.
+func (cpu *CPU) DisableInterrupt(index int) {
+	write_ecfg(read_ecfg() &^ (1 << index))
+}
+
+// WaitInterrupt suspends execution in low-power state until an interrupt is
+// received.
+func (cpu *CPU) WaitInterrupt() {
+	idle()
+}
+
+// InterruptStatus returns the pending interrupt lines as reported by the
+// ESTAT.IS field; each set bit corresponds to an interrupt source (e.g. bit
+// [TimerInterrupt] for the constant frequency timer). It allows an interrupt
+// service routine to determine which interrupt fired.
+func (cpu *CPU) InterruptStatus() uint64 {
+	return read_estat() & 0x1fff
+}
+
+// ServiceInterrupts puts the calling goroutine in wait state, its execution is
+// resumed when an IRQ exception is received, the argument function can be set
+// to service signaled interrupts.
+func (cpu *CPU) ServiceInterrupts(isr func()) {
+	if isr == nil {
+		isr = func() {}
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, IRQ_SIGNAL)
+
+	for {
+		// To avoid losing interrupts, re-enabling must happen only after
+		// we are waiting.
+		go cpu.EnableInterrupts()
+		<-c
+		isr()
+	}
+}

--- a/loong64/irq.s
+++ b/loong64/irq.s
@@ -1,0 +1,14 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// func idle()
+TEXT ·idle(SB),NOSPLIT|NOFRAME,$0
+	WORD	$0x06488000	// idle 0
+	RET

--- a/loong64/loong64.go
+++ b/loong64/loong64.go
@@ -1,0 +1,66 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package loong64 provides support for LoongArch 64-bit architecture specific
+// operations.
+//
+// The following architectures/cores are supported/tested:
+//   - LA64 (single-core)
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=loong64` as
+// supported by the TamaGo framework for bare metal Go, see
+// https://github.com/usbarmory/tamago.
+package loong64
+
+import (
+	"math"
+	"runtime/goos"
+	"sync"
+)
+
+// This package supports 64-bit cores.
+const XLEN = 64
+
+// CPU instance
+type CPU struct {
+	sync.Mutex
+
+	// Counter represents the function to obtain the system counter for
+	// operation of [CPU.GetTime] and [CPU.SetTime]. When left nil it defaults
+	// to [Rdtime] at [CPU.Init] time.
+	Counter func() uint64
+
+	// Timer multiplier
+	TimerMultiplier float64
+	// Timer offset in nanoseconds
+	TimerOffset int64
+}
+
+// defined in loong64.s
+func exit(int32)
+
+// DefaultIdleGovernor is the default CPU idle time management function.
+func (cpu *CPU) DefaultIdleGovernor(pollUntil int64) {
+	// we have nothing to do forever
+	if pollUntil == math.MaxInt64 {
+		exit(0)
+	}
+}
+
+// Init performs initialization of an LA64 core instance.
+func (cpu *CPU) Init() {
+	goos.Exit = exit
+	goos.Idle = cpu.DefaultIdleGovernor
+
+	if cpu.Counter == nil {
+		cpu.Counter = Rdtime
+	}
+
+	cpu.SetExceptionHandler(trapHandler)
+	cpu.initTimers()
+}

--- a/loong64/loong64.s
+++ b/loong64/loong64.s
@@ -1,0 +1,40 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// The Go LoongArch assembler provides no mnemonics for privileged CSR access,
+// exception return (ertn) or the idle instruction, therefore these are emitted
+// as hand-encoded WORD directives, verified via `go tool objdump`:
+//
+//	csrwr Rd, csr = 0x04000000 | (csr<<10) | (1<<5) | Rd
+//	csrrd Rd, csr = 0x04000000 | (csr<<10) | Rd
+//	idle  0       = 0x06488000
+//
+// CSR numbers: EUEN=0x2.
+
+TEXT ·Init(SB),NOSPLIT|NOFRAME,$0
+	// enable the floating point unit (EUEN.FPE)
+	MOVV	$1, R4
+	WORD	$0x04000824	// csrwr R4, EUEN(0x2)
+
+	// set stack pointer to RamStart + RamSize - RamStackOffset
+	MOVV	runtime∕goos·RamStart(SB), R3
+	MOVV	runtime∕goos·RamSize(SB), R5
+	MOVV	runtime∕goos·RamStackOffset(SB), R6
+	ADDVU	R5, R3, R3
+	SUBVU	R6, R3, R3
+
+	JMP	_rt0_tamago_start(SB)
+
+// func exit(int32)
+TEXT ·exit(SB),NOSPLIT|NOFRAME,$0-4
+	// wait forever in low-power state
+again:
+	WORD	$0x06488000	// idle 0
+	JMP	again

--- a/loong64/smp.go
+++ b/loong64/smp.go
@@ -1,0 +1,14 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+// ID returns the processor core identifier as reported by the CPUID CSR.
+func (cpu *CPU) ID() uint64 {
+	return read_cpuid() & 0x1ff
+}

--- a/loong64/timer.go
+++ b/loong64/timer.go
@@ -1,0 +1,97 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package loong64
+
+// nanoseconds per second
+const refFreq int64 = 1e9
+
+// Rdtime returns the constant frequency stable counter value.
+//
+// defined in timer.s
+func Rdtime() uint64
+
+// read_cpucfg returns the given CPUCFG configuration word.
+//
+// defined in timer.s
+func read_cpucfg(sel uint64) uint64
+
+// initTimers derives the stable counter frequency from CPUCFG and configures
+// the timer scaling factor accordingly.
+func (cpu *CPU) initTimers() {
+	// CPUCFG word 0x4 holds the constant frequency base, word 0x5 its
+	// multiplier (bits 15:0) and divider (bits 31:16).
+	base := read_cpucfg(0x4)
+	cfg5 := read_cpucfg(0x5)
+
+	mul := cfg5 & 0xffff
+	div := (cfg5 >> 16) & 0xffff
+
+	if div == 0 {
+		div = 1
+	}
+
+	freq := base * mul / div
+
+	if freq == 0 {
+		freq = 1
+	}
+
+	cpu.TimerMultiplier = float64(refFreq) / float64(freq)
+}
+
+// GetTime returns the system time in nanoseconds.
+func (cpu *CPU) GetTime() int64 {
+	return int64(float64(cpu.Counter())*cpu.TimerMultiplier) + cpu.TimerOffset
+}
+
+// SetTime adjusts the system time to the argument nanoseconds value.
+func (cpu *CPU) SetTime(ns int64) {
+	if cpu.TimerMultiplier == 0 {
+		return
+	}
+
+	cpu.TimerOffset = ns - int64(float64(cpu.Counter())*cpu.TimerMultiplier)
+}
+
+// TimerInterrupt is the ESTAT.IS line index of the constant frequency timer
+// interrupt.
+const TimerInterrupt = 11
+
+// TCFG configuration bits.
+const (
+	tcfgEnable   = 1 << 0
+	tcfgPeriodic = 1 << 1
+)
+
+// SetTimer programs the constant frequency timer to fire an interrupt after the
+// argument number of nanoseconds, periodically when periodic is set. The timer
+// interrupt line must be unmasked with [CPU.EnableInterrupt](TimerInterrupt)
+// and interrupts enabled with [CPU.EnableInterrupts].
+func (cpu *CPU) SetTimer(ns int64, periodic bool) {
+	if cpu.TimerMultiplier == 0 {
+		return
+	}
+
+	// convert nanoseconds to timer ticks
+	ticks := uint64(float64(ns) / cpu.TimerMultiplier)
+
+	// the initial value occupies TCFG bits [n:2] and must be word aligned
+	cfg := (ticks &^ 0x3) | tcfgEnable
+
+	if periodic {
+		cfg |= tcfgPeriodic
+	}
+
+	write_tcfg(cfg)
+}
+
+// ClearTimerInterrupt acknowledges a pending timer interrupt.
+func (cpu *CPU) ClearTimerInterrupt() {
+	write_ticlr(1)
+}

--- a/loong64/timer.s
+++ b/loong64/timer.s
@@ -1,0 +1,26 @@
+// LoongArch 64-bit processor support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// The Go LoongArch assembler follows the Plan 9 destination-last operand
+// convention, therefore for `rdtime.d rd, rj` and `cpucfg rd, rj` the result
+// register (rd) is the last operand.
+
+// func Rdtime() uint64
+TEXT ·Rdtime(SB),NOSPLIT,$0-8
+	RDTIMED	R4, R5		// R5 = stable counter value, R4 = counter id
+	MOVV	R5, ret+0(FP)
+	RET
+
+// func read_cpucfg(sel uint64) uint64
+TEXT ·read_cpucfg(SB),NOSPLIT,$0-16
+	MOVV	sel+0(FP), R4
+	CPUCFG	R4, R5		// R5 = cpucfg[R4]
+	MOVV	R5, ret+8(FP)
+	RET

--- a/soc/loongson/ls3a5000/README.md
+++ b/soc/loongson/ls3a5000/README.md
@@ -1,0 +1,69 @@
+TamaGo - bare metal Go - Loongson 3A5000/LS7A support
+=====================================================
+
+tamago | https://github.com/usbarmory/tamago  
+
+Copyright (c) The TamaGo Authors. All Rights Reserved.  
+
+![TamaGo gopher](https://github.com/usbarmory/tamago/wiki/images/tamago.svg?sanitize=true)
+
+Authors
+=======
+
+tannevaled  
+https://github.com/tannevaled  
+
+Introduction
+============
+
+TamaGo is a framework that enables compilation and execution of unencumbered Go
+applications on bare metal processors.
+
+The `ls3a5000` package provides support for Loongson 3A5000/3A6000 processors
+paired with the LS7A bridge, as emulated by the QEMU LoongArch `virt` machine.
+
+The package exposes the LoongArch CPU instance along with the NS16550 legacy
+serial console; the constant-frequency stable timer feeds the runtime system
+clock.
+
+Documentation
+=============
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/usbarmory/tamago.svg)](https://pkg.go.dev/github.com/usbarmory/tamago)
+
+For TamaGo see its [repository](https://github.com/usbarmory/tamago) and
+[project wiki](https://github.com/usbarmory/tamago/wiki) for information.
+
+For the CPU driver support see package
+[loong64](https://github.com/usbarmory/tamago/tree/master/loong64).
+
+The package API documentation can be found on
+[pkg.go.dev](https://pkg.go.dev/github.com/usbarmory/tamago).
+
+Supported hardware
+==================
+
+| SoC             | Related board packages                                                        | Peripheral drivers |
+|-----------------|-------------------------------------------------------------------------------|--------------------|
+| Loongson 3A5000 | [qemu/virt](https://github.com/usbarmory/tamago/blob/master/board/qemu/virt)  | UART               |
+
+Secure random number generation
+===============================
+
+The Loongson SoC does not currently wire an entropy source, therefore at
+runtime initialization a DRBG is seeded with the CPU timer. This is unsuitable
+for secure random number generation and must therefore be overridden through
+`SetRNG` to ensure secure operation of Go crypto.
+
+License
+=======
+
+tamago | https://github.com/usbarmory/tamago  
+Copyright (c) The TamaGo Authors. All Rights Reserved.
+
+These source files are distributed under the BSD-style license found in the
+[LICENSE](https://github.com/usbarmory/tamago/blob/master/LICENSE) file.
+
+The TamaGo logo is adapted from the Go gopher designed by Renee French and
+licensed under the Creative Commons 3.0 Attributions license. Go Gopher vector
+illustration by Hugo Arganda.

--- a/soc/loongson/ls3a5000/init.go
+++ b/soc/loongson/ls3a5000/init.go
@@ -1,0 +1,16 @@
+// Loongson 3A5000/LS7A support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package ls3a5000
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname ramStackOffset runtime/goos.RamStackOffset
+var ramStackOffset uint64 = 0x100

--- a/soc/loongson/ls3a5000/ls3a5000.go
+++ b/soc/loongson/ls3a5000/ls3a5000.go
@@ -1,0 +1,50 @@
+// Loongson 3A5000/LS7A support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package ls3a5000 provides support for Loongson 3A5000/3A6000 processors
+// paired with the LS7A bridge, as emulated by the QEMU LoongArch `virt`
+// machine.
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=loong64` as
+// supported by the TamaGo framework for bare metal Go on LoongArch SoCs, see
+// https://github.com/usbarmory/tamago.
+package ls3a5000
+
+import (
+	"github.com/usbarmory/tamago/loong64"
+	"github.com/usbarmory/tamago/soc/loongson/uart"
+)
+
+// Peripheral registers
+const (
+	// LS7A legacy NS16550 console, also exposed by the QEMU `virt` machine
+	UART0_BASE = 0x1fe001e0
+)
+
+// Peripheral instances
+var (
+	// LA64 is the LoongArch 64-bit CPU instance
+	LA64 = &loong64.CPU{
+		// Counter must be set at package initialization as Nanotime
+		// is invoked by the runtime before [Init].
+		Counter:         loong64.Rdtime,
+		TimerMultiplier: 1,
+		TimerOffset:     1,
+	}
+
+	// UART0 is the LS7A legacy serial console
+	UART0 = &uart.UART{
+		Base: UART0_BASE,
+	}
+)
+
+// Init takes care of the lower level SoC initialization triggered early in
+// runtime setup.
+func Init() {
+	LA64.Init()
+}

--- a/soc/loongson/ls3a5000/mem.go
+++ b/soc/loongson/ls3a5000/mem.go
@@ -1,0 +1,16 @@
+// Loongson 3A5000/LS7A support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package ls3a5000
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname ramStart runtime/goos.RamStart
+var ramStart uint64 = 0x00000000

--- a/soc/loongson/ls3a5000/rng.go
+++ b/soc/loongson/ls3a5000/rng.go
@@ -1,0 +1,35 @@
+// Loongson 3A5000/LS7A support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package ls3a5000
+
+import (
+	"encoding/binary"
+	"time"
+	_ "unsafe"
+
+	"github.com/usbarmory/tamago/internal/rng"
+)
+
+//go:linkname initRNG runtime/goos.InitRNG
+func initRNG() {
+	drbg := &rng.DRBG{}
+	binary.LittleEndian.PutUint64(drbg.Seed[:], uint64(time.Now().UnixNano()))
+	rng.GetRandomDataFn = drbg.GetRandomData
+}
+
+// SetRNG allows to override the internal random number generator function used
+// by TamaGo on the Loongson SoC.
+//
+// At runtime initialization this package seeds a DRBG with the CPU timer as no
+// entropy source is currently wired. This is unsuitable for secure random
+// number generation and must therefore be overridden to ensure secure operation
+// of Go crypto.
+func SetRNG(getRandomData func([]byte)) {
+	rng.GetRandomDataFn = getRandomData
+}

--- a/soc/loongson/ls3a5000/timer.go
+++ b/soc/loongson/ls3a5000/timer.go
@@ -1,0 +1,18 @@
+// Loongson 3A5000/LS7A support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package ls3a5000
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname nanotime runtime/goos.Nanotime
+func nanotime() int64 {
+	return LA64.GetTime()
+}

--- a/soc/loongson/uart/uart.go
+++ b/soc/loongson/uart/uart.go
@@ -1,0 +1,96 @@
+// NS16550-compatible UART driver
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package uart implements a driver for NS16550-compatible UART controllers,
+// such as the legacy console found on Loongson LS7A based platforms and the
+// QEMU LoongArch `virt` machine.
+//
+// This package is only meant to be used with `GOOS=tamago GOARCH=loong64` as
+// supported by the TamaGo framework for bare metal Go, see
+// https://github.com/usbarmory/tamago.
+package uart
+
+import (
+	"github.com/usbarmory/tamago/internal/reg"
+)
+
+// NS16550 register offsets (register shift 0, byte access).
+const (
+	rbr = 0x00 // Receiver Buffer Register (read, DLAB=0)
+	thr = 0x00 // Transmitter Holding Register (write, DLAB=0)
+	ier = 0x01 // Interrupt Enable Register
+	fcr = 0x02 // FIFO Control Register
+	lcr = 0x03 // Line Control Register
+	lsr = 0x05 // Line Status Register
+)
+
+// LSR bit fields.
+const (
+	lsrDR   = 1 << 0 // Data Ready
+	lsrTHRE = 1 << 5 // Transmitter Holding Register Empty
+)
+
+// UART represents a serial port instance.
+type UART struct {
+	// Base register address
+	Base uint32
+}
+
+// Init initializes the UART for 8N1 operation with FIFOs enabled. The baud
+// rate divisor is left untouched as it is irrelevant under emulation.
+func (hw *UART) Init() {
+	reg.Write8(hw.Base+ier, 0x00) // disable interrupts
+	reg.Write8(hw.Base+fcr, 0xc7) // enable and clear RX/TX FIFOs, 14-byte trigger
+	reg.Write8(hw.Base+lcr, 0x03) // 8 bits, no parity, 1 stop bit
+}
+
+// Tx transmits a single character to the serial port.
+func (hw *UART) Tx(c byte) {
+	for reg.Read8(hw.Base+lsr)&lsrTHRE == 0 {
+		// wait for the transmitter holding register to drain
+	}
+
+	reg.Write8(hw.Base+thr, c)
+}
+
+// Rx receives a single character from the serial port, the second return value
+// indicates whether a character was available.
+func (hw *UART) Rx() (c byte, valid bool) {
+	if reg.Read8(hw.Base+lsr)&lsrDR == 0 {
+		return
+	}
+
+	return reg.Read8(hw.Base + rbr), true
+}
+
+// Write transmits the argument buffer to the serial port.
+func (hw *UART) Write(buf []byte) (n int, _ error) {
+	for _, c := range buf {
+		hw.Tx(c)
+	}
+
+	return len(buf), nil
+}
+
+// Read receives the available bytes from the serial port into the argument
+// buffer.
+func (hw *UART) Read(buf []byte) (n int, _ error) {
+	var valid bool
+
+	for n < len(buf) {
+		buf[n], valid = hw.Rx()
+
+		if !valid {
+			break
+		}
+
+		n++
+	}
+
+	return
+}


### PR DESCRIPTION
Adds `GOOS=tamago GOARCH=loong64` (LoongArch 64-bit) support, mirroring the existing riscv64 layering (arch package → SoC drivers → board glue). Follow-up to the compiler-side support in usbarmory/tamago-go#18. Refs #70.

### What's included

- **`loong64/`** — LoongArch 64-bit arch package: CPU bring-up (FPU enable, stack), constant-frequency stable timer (`rdtime.d` + `CPUCFG`), single-entry exception vector with cause/BADV reporting, IRQ enable/disable/wait, `CPUCFG` feature detection, core id. The CPU runs in Direct Address translation mode (no page tables).
- **`soc/loongson/uart`** — NS16550 serial driver; **`soc/loongson/ls3a5000`** — Loongson 3A5000/LS7A SoC glue (console, timer→Nanotime, DRBG RNG, RamStart).
- **`board/qemu/virt`** — QEMU LoongArch `virt` machine board (Hwinit1, Printk, RamSize).
- `internal/reg/reg_loong64.s` and a small `internal/reg/reg8.go` (NS16550 byte registers).

### Assembler note

The Go LoongArch assembler exposes no privileged CSR access, `ertn` or `idle` mnemonics, so those are emitted as hand-encoded `WORD` directives, each verified with `go tool objdump` (e.g. `csrwr R4, csr = 0x04000000 | (csr<<10) | 0x24`).

### Validation

Built and run end-to-end under `qemu-system-loongarch64 -M virt` (v11.0.1):

```
qemu-system-loongarch64 -M virt -m 256M -nographic -kernel <elf>
```

Verified: boot + serial console, goroutine scheduling, GC, accurate `time.Sleep` (20 ms → ~21 ms), `crypto/rand`, and clean exception reporting on a deliberate fault (`ecode 8 ADE`, correct `badv`, Go stack trace). Existing riscv64/amd64/arm64/arm boards still build; `go vet` and `gofmt` clean.

Unlike the riscv64 `qemu` targets no BIOS is required — the QEMU `virt` machine loads the ELF and jumps to its entry directly (the low 2 MiB is reserved for boot info + device tree, so the text segment is linked above it, e.g. `-T 0x1000000`).

### Scope

Primary hardware target is Loongson 3A5000/3A6000 + LS7A; QEMU `virt` is the reference target validated here. A dedicated real-silicon board (with cached DMW windows, real memory map) is a natural follow-up — QEMU `virt` is the only LoongArch target testable in emulation, so real-HW specifics are intentionally out of scope for this PR. Happy to adjust SoC/package naming to your preference.
