### PR TITLE
internal/reg: fix Get16

### DIFF
--- a/internal/reg/reg16.go
+++ b/internal/reg/reg16.go
@@ -16,9 +16,11 @@ import (
 // As sync/atomic does not provide 16-bit support, note that these functions do
 // not necessarily enforce memory ordering.
 
-func Get16(addr uint32, pos int) {
+func Get16(addr uint32, pos int) bool {
 	reg := (*uint16)(unsafe.Pointer(uintptr(addr)))
-	*reg |= (1 << pos)
+	r := *reg
+
+	return (int(r)>>pos)&1 == 1
 }
 
 func Set16(addr uint32, pos int) {


### PR DESCRIPTION
Get16 modifies the register by setting the requested bit and returns no value, duplicating Set16 instead of matching Get and Get64.

Read the bit and return its state without modifying the register.