### PR TITLE
flexcom: report complete writes

### DIFF
--- a/soc/microchip/flexcom/flexcom.go
+++ b/soc/microchip/flexcom/flexcom.go
@@ -196,8 +196,9 @@ func (hw *FLEXCOM) Rx(block bool) (c byte, valid bool) {
 
 // Write data from buffer to serial port.
 func (hw *FLEXCOM) Write(buf []byte) (n int, _ error) {
-	for n = range buf {
+	for n < len(buf) {
 		hw.Tx(buf[n])
+		n++
 	}
 
 	return


### PR DESCRIPTION
Write transmits every byte but returns the final slice index rather than the number of bytes written. A one-byte write therefore returns zero with a nil error, violating the io.Writer contract.

Increment the count after each successful transmission so complete writes return len(buf).