### PR TITLE
flexcom: add buffered interrupt-driven USART receive

### DIFF
--- a/internal/reg/reg8.go
+++ b/internal/reg/reg8.go
@@ -1,0 +1,14 @@
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package reg
+
+// Read8 reads an 8-bit register.
+func Read8(addr uint32) uint8
+
+// Write8 writes an 8-bit register.
+func Write8(addr uint32, val uint8)

--- a/internal/reg/reg_amd64.s
+++ b/internal/reg/reg_amd64.s
@@ -20,6 +20,23 @@ TEXT ·Move(SB),$0-8
 
 	RET
 
+// func Read8(addr uint32) uint8
+TEXT ·Read8(SB),$0-9
+	MOVL	addr+0(FP), AX
+	MOVBLZX	(AX), BX
+	MOVB	BX, ret+8(FP)
+
+	RET
+
+// func Write8(addr uint32, val uint8)
+TEXT ·Write8(SB),$0-5
+	MOVL	addr+0(FP), AX
+	MOVBLZX	val+4(FP), BX
+
+	MOVB	BX, (AX)
+
+	RET
+
 // func Write(addr uint32, val uint32)
 TEXT ·Write(SB),$0-8
 	MOVL	addr+0(FP), AX

--- a/internal/reg/reg_arm.s
+++ b/internal/reg/reg_arm.s
@@ -20,6 +20,23 @@ TEXT ·Move(SB),$0-8
 
 	RET
 
+// func Read8(addr uint32) uint8
+TEXT ·Read8(SB),$0-5
+	MOVW	addr+0(FP), R0
+	MOVBU	(R0), R1
+	MOVB	R1, ret+4(FP)
+
+	RET
+
+// func Write8(addr uint32, val uint8)
+TEXT ·Write8(SB),$0-5
+	MOVW	addr+0(FP), R0
+	MOVBU	val+4(FP), R1
+
+	MOVB	R1, (R0)
+
+	RET
+
 // func Write(addr uint32, val uint32)
 TEXT ·Write(SB),$0-8
 	MOVW	addr+0(FP), R0

--- a/internal/reg/reg_arm64.s
+++ b/internal/reg/reg_arm64.s
@@ -20,6 +20,23 @@ TEXT ·Move(SB),$0-8
 
 	RET
 
+// func Read8(addr uint32) uint8
+TEXT ·Read8(SB),$0-9
+	MOVWU	addr+0(FP), R0
+	MOVBU	(R0), R1
+	MOVB	R1, ret+8(FP)
+
+	RET
+
+// func Write8(addr uint32, val uint8)
+TEXT ·Write8(SB),$0-5
+	MOVWU	addr+0(FP), R0
+	MOVBU	val+4(FP), R1
+
+	MOVB	R1, (R0)
+
+	RET
+
 // func Write(addr uint32, val uint32)
 TEXT ·Write(SB),$0-8
 	MOVWU	addr+0(FP), R0

--- a/internal/reg/reg_riscv64.s
+++ b/internal/reg/reg_riscv64.s
@@ -20,6 +20,23 @@ TEXT ·Move(SB),$0-8
 
 	RET
 
+// func Read8(addr uint32) uint8
+TEXT ·Read8(SB),$0-9
+	MOVW	addr+0(FP), T0
+	MOVBU	(T0), T1
+	MOVB	T1, ret+8(FP)
+
+	RET
+
+// func Write8(addr uint32, val uint8)
+TEXT ·Write8(SB),$0-5
+	MOVW	addr+0(FP), T0
+	MOVBU	val+4(FP), T1
+
+	MOVB	T1, (T0)
+
+	RET
+
 // func Write(addr uint32, val uint32)
 TEXT ·Write(SB),$0-8
 	MOVW	addr+0(FP), T0

--- a/soc/microchip/flexcom/flexcom.go
+++ b/soc/microchip/flexcom/flexcom.go
@@ -53,6 +53,7 @@ const (
 	US_MR_CHRL   = 6
 
 	FLEX_US_IER  = 0x08
+	FLEX_US_IDR  = 0x0c
 	IER_TXRDY_IE = 1
 	IER_RXRDY_IE = 0
 
@@ -85,6 +86,7 @@ type FLEXCOM struct {
 	us_cr   uint32
 	us_mr   uint32
 	us_ier  uint32
+	us_idr  uint32
 	us_csr  uint32
 	us_rhr  uint32
 	us_thr  uint32
@@ -107,6 +109,7 @@ func (hw *FLEXCOM) Init() {
 	hw.us_cr = hw.Base + FLEX_USART_OFFSET + FLEX_US_CR
 	hw.us_mr = hw.Base + FLEX_USART_OFFSET + FLEX_US_MR
 	hw.us_ier = hw.Base + FLEX_USART_OFFSET + FLEX_US_IER
+	hw.us_idr = hw.Base + FLEX_USART_OFFSET + FLEX_US_IDR
 	hw.us_csr = hw.Base + FLEX_USART_OFFSET + FLEX_US_CSR
 	hw.us_rhr = hw.Base + FLEX_USART_OFFSET + FLEX_US_RHR
 	hw.us_thr = hw.Base + FLEX_USART_OFFSET + FLEX_US_THR
@@ -129,10 +132,10 @@ func (hw *FLEXCOM) setup() {
 	reg.Write(hw.us_brgr, uint32(cd))
 
 	// reset the receiver and transmitter
-	reg.SetN(hw.us_cr, US_CR_RSTRX, 1, 1)
-	reg.SetN(hw.us_cr, US_CR_RSTTX, 1, 1)
-	reg.SetN(hw.us_cr, US_CR_RXDIS, 1, 1)
-	reg.SetN(hw.us_cr, US_CR_TXDIS, 1, 1)
+	reg.Write(hw.us_cr, 1<<US_CR_RSTRX)
+	reg.Write(hw.us_cr, 1<<US_CR_RSTTX)
+	reg.Write(hw.us_cr, 1<<US_CR_RXDIS)
+	reg.Write(hw.us_cr, 1<<US_CR_TXDIS)
 
 	// set 8N1 mode
 	reg.SetN(hw.us_mr, US_MR_PAR, 0b111, 4)
@@ -143,15 +146,19 @@ func (hw *FLEXCOM) setup() {
 	reg.ClearN(hw.us_mr, US_MR_SYNC, 1)
 
 	// enable Tx and RX
-	reg.SetN(hw.us_cr, US_CR_RXEN, 1, 1)
-	reg.SetN(hw.us_cr, US_CR_TXEN, 1, 1)
+	reg.Write(hw.us_cr, 1<<US_CR_RXEN)
+	reg.Write(hw.us_cr, 1<<US_CR_TXEN)
 }
 
-// EnableInterrupt enables interrupt generation for receive FIFOs. Once enabled
-// [FLEXCOM.Read] and [FLEXCOM.Rx] block, as required, on the argument channel
-// rather than polling for valid data.
+// EnableInterrupt configures interrupt-driven receive waits. A nil channel
+// disables receive interrupts and restores polling.
 func (hw *FLEXCOM) EnableInterrupt(rx chan bool) {
-	reg.SetTo(hw.us_ier, IER_RXRDY_IE, rx != nil)
+	if rx == nil {
+		reg.Write(hw.us_idr, 1<<IER_RXRDY_IE)
+	} else {
+		reg.Write(hw.us_ier, 1<<IER_RXRDY_IE)
+	}
+
 	hw.rx = rx
 }
 

--- a/soc/microchip/flexcom/flexcom.go
+++ b/soc/microchip/flexcom/flexcom.go
@@ -38,6 +38,8 @@ const (
 	FLEX_US_CR    = 0x00
 	US_CR_FIFODIS = 31
 	US_CR_FIFOEN  = 30
+	US_CR_RXFCLR  = 25
+	US_CR_TXFCLR  = 24
 	US_CR_TXDIS   = 7
 	US_CR_TXEN    = 6
 	US_CR_RXDIS   = 5
@@ -66,6 +68,8 @@ const (
 
 	FLEX_US_BRGR = 0x20
 	US_BRGR_CD   = 0
+
+	FLEX_US_FMR = 0xa0
 )
 
 // FLEXCOM represents a Flexible Serial Communication controller instance.
@@ -91,6 +95,7 @@ type FLEXCOM struct {
 	us_rhr  uint32
 	us_thr  uint32
 	us_brgr uint32
+	us_fmr  uint32
 
 	rx chan bool
 }
@@ -114,6 +119,7 @@ func (hw *FLEXCOM) Init() {
 	hw.us_rhr = hw.Base + FLEX_USART_OFFSET + FLEX_US_RHR
 	hw.us_thr = hw.Base + FLEX_USART_OFFSET + FLEX_US_THR
 	hw.us_brgr = hw.Base + FLEX_USART_OFFSET + FLEX_US_BRGR
+	hw.us_fmr = hw.Base + FLEX_USART_OFFSET + FLEX_US_FMR
 
 	hw.setup()
 }
@@ -145,6 +151,12 @@ func (hw *FLEXCOM) setup() {
 	// set asynchronous mode (UART)
 	reg.ClearN(hw.us_mr, US_MR_SYNC, 1)
 
+	// single-data FIFOs
+	reg.Write(hw.us_fmr, 0)
+	reg.Write(hw.us_cr, 1<<US_CR_FIFOEN)
+	reg.Write(hw.us_cr, 1<<US_CR_RXFCLR)
+	reg.Write(hw.us_cr, 1<<US_CR_TXFCLR)
+
 	// enable Tx and RX
 	reg.Write(hw.us_cr, 1<<US_CR_RXEN)
 	reg.Write(hw.us_cr, 1<<US_CR_TXEN)
@@ -168,37 +180,27 @@ func (hw *FLEXCOM) Tx(c byte) {
 		// wait for TX FIFO to have room for a character
 	}
 
-	reg.Write(hw.us_thr, uint32(c))
+	reg.Write8(hw.us_thr, c)
 }
 
 // Rx receives a single character from the serial port, waiting for data to
 // become available if the argument is true.
 func (hw *FLEXCOM) Rx(block bool) (c byte, valid bool) {
-	if hw.rx != nil {
-		if block {
+	for {
+		if reg.GetN(hw.us_csr, US_CSR_RXRDY, 1) == 1 {
+			return reg.Read8(hw.us_rhr), true
+		}
+
+		if !block {
+			return
+		}
+
+		if hw.rx != nil {
 			<-hw.rx
 		} else {
-			select {
-			case <-hw.rx:
-			default:
-				return
-			}
-		}
-	}
-
-	if reg.GetN(hw.us_csr, US_CSR_RXRDY, 1) == 1 {
-		return byte(reg.Read(hw.us_rhr)), true
-	}
-
-	if block && hw.rx == nil {
-		for reg.GetN(hw.us_csr, US_CSR_RXRDY, 1) == 0 {
 			runtime.Gosched()
 		}
-
-		return byte(reg.Read(hw.us_rhr)), true
 	}
-
-	return
 }
 
 // Write data from buffer to serial port.


### PR DESCRIPTION
This series corrects FLEXCOM write-only register access and improves the USART receive path when interrupts and hardware FIFOs are used.