### PR TITLE
nuvoton: fix UART buffer write

### DIFF
--- a/soc/nuvoton/uart/uart.go
+++ b/soc/nuvoton/uart/uart.go
@@ -84,7 +84,7 @@ func (hw *UART) Tx(c byte) {
 
 // Write data from buffer to serial port.
 func (hw *UART) Write(buf []byte) (n int, _ error) {
-	for _, c = range buf {
+	for _, c := range buf {
 		hw.Tx(c)
 	}
 


### PR DESCRIPTION
The range loop assigns to an undeclared variable, so the Nuvoton UART package does not compile. Declare the iteration variable in the loop.