### PR TITLE
devcpu: harden manual frame extraction and injection

### DIFF
--- a/board/microchip/lan9696evb/const.go
+++ b/board/microchip/lan9696evb/const.go
@@ -107,6 +107,12 @@ const (
 	PORT_ENA              = 19
 )
 
+// Disassembler registers
+const (
+	DEV_TX_STOP_WM_CFG = DSM_CFG + 0x550
+	DEV_TX_CNT_CLR     = 0
+)
+
 // Assembler registers
 const (
 	PORT_CFG_BASE   = lan969x.ASM_BASE + 0x4780 + 0x21c

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	MAC_FID             = 1
-	managementPortIndex = 29
+	ManagementPortIndex = PORT29
 )
 
 // On the LAN969x 24-port EVB the management network interface is port D29,
@@ -26,7 +26,7 @@ const (
 //
 // CPU port 0 (D30) is used for injection and extraction of frames.
 var ManagementPort = &devcpu.Port{
-	Index:    managementPortIndex,
+	Index:    PORT29,
 	IRQ:      lan969x.XTR_READY_IRQ,
 	Queue:    lan969x.DEVCPU_QS,
 	Analyzer: lan969x.ANA,
@@ -34,8 +34,8 @@ var ManagementPort = &devcpu.Port{
 	FID:      MAC_FID,
 }
 
-func resetInjectionFlowControl() {
-	reg.Set(DEV_TX_STOP_WM_CFG+managementPortIndex*4, DEV_TX_CNT_CLR)
+func resetInjectionFlowControl(port uint32) {
+	reg.Set(DEV_TX_STOP_WM_CFG+port*4, DEV_TX_CNT_CLR)
 }
 
 func enablePort() (err error) {
@@ -53,7 +53,7 @@ func enablePort() (err error) {
 	initCapture(PORT_CFG30)
 
 	// reset injection flow control
-	resetInjectionFlowControl()
+	resetInjectionFlowControl(PORT29)
 
 	return nil
 }

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -16,19 +16,26 @@ import (
 	"github.com/usbarmory/tamago/soc/microchip/miim"
 )
 
-const MAC_FID = 1
+const (
+	MAC_FID             = 1
+	managementPortIndex = 29
+)
 
 // On the LAN969x 24-port EVB the management network interface is port D29,
 // connected through DEV_RGMII1 with a Microchip LAN8840 PHY.
 //
 // CPU port 0 (D30) is used for injection and extraction of frames.
 var ManagementPort = &devcpu.Port{
-	Index:    29,
+	Index:    managementPortIndex,
 	IRQ:      lan969x.XTR_READY_IRQ,
 	Queue:    lan969x.DEVCPU_QS,
 	Analyzer: lan969x.ANA,
 	Enable:   enablePort,
 	FID:      MAC_FID,
+}
+
+func resetInjectionFlowControl() {
+	reg.Set(DEV_TX_STOP_WM_CFG+managementPortIndex*4, DEV_TX_CNT_CLR)
 }
 
 func enablePort() (err error) {
@@ -44,6 +51,9 @@ func enablePort() (err error) {
 
 	// init capture on CPU port 0 (D30)
 	initCapture(PORT_CFG30)
+
+	// reset injection flow control
+	resetInjectionFlowControl()
 
 	return nil
 }

--- a/soc/microchip/devcpu/const.go
+++ b/soc/microchip/devcpu/const.go
@@ -10,8 +10,10 @@ package devcpu
 
 // Common fields
 const (
-	CFG_MODE = 2
-	IFH_LEN  = 36
+	CFG_MODE            = 2
+	CFG_STATUS_WORD_POS = 1
+	CFG_BYTE_SWAP       = 0
+	IFH_LEN             = 36
 )
 
 // Frame extraction registers
@@ -19,19 +21,20 @@ const (
 	XTR              = 0x00
 	XTR_GRP_CFG      = XTR + 0x00
 	XTR_RD           = XTR + 0x08
+	XTR_FRM_PRUNING  = XTR + 0x10
 	XTR_DATA_PRESENT = XTR + 0x1c
 )
 
 // Special frame error values (little endian)
 const (
 	RD_EOF_UNUSED_0  = 0x00000080
-	RD_EOF_UNUSED_1  = 0x10000080
-	RD_EOF_UNUSED_2  = 0x20000080
-	RD_EOF_UNUSED_3  = 0x30000080
-	RD_EOF_TRUNCATED = 0x40000080
-	RD_EOF_ABORTED   = 0x50000080
-	RD_ESCAPE        = 0x60000080
-	RD_NOT_READY     = 0x70000080
+	RD_EOF_UNUSED_1  = 0x01000080
+	RD_EOF_UNUSED_2  = 0x02000080
+	RD_EOF_UNUSED_3  = 0x03000080
+	RD_EOF_TRUNCATED = 0x04000080
+	RD_EOF_ABORTED   = 0x05000080
+	RD_ESCAPE        = 0x06000080
+	RD_NOT_READY     = 0x07000080
 )
 
 // Frame injection registers

--- a/soc/microchip/devcpu/const.go
+++ b/soc/microchip/devcpu/const.go
@@ -45,7 +45,13 @@ const (
 
 	INJ_CTRL       = INJ + 0x10
 	CTRL_GAP_SIZE  = 21
+	CTRL_ABORT     = 20
 	CTRL_EOF       = 19
 	CTRL_SOF       = 18
 	CTRL_VLD_BYTES = 16
+
+	INJ_STATUS                 = INJ + 0x18
+	INJ_STATUS_WMARK_REACHED   = 4
+	INJ_STATUS_FIFO_RDY        = 2
+	INJ_STATUS_INJ_IN_PROGRESS = 0
 )

--- a/soc/microchip/devcpu/port.go
+++ b/soc/microchip/devcpu/port.go
@@ -23,10 +23,34 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/usbarmory/tamago/internal/reg"
 	"github.com/usbarmory/tamago/soc/microchip/analyzer"
 )
+
+const (
+	injectionPollInterval = 1 * time.Millisecond
+	injectionTimeout      = 1 * time.Second
+	minimumFrameSize      = 60
+)
+
+// ErrorCounters represents frame path errors since the most recent call to
+// [Port.Init].
+type ErrorCounters struct {
+	RxTruncated         uint64
+	RxAborted           uint64
+	RxEmpty             uint64
+	RxOversized         uint64
+	RxInvalid           uint64
+	RxShortHeader       uint64
+	TxWatermarkTimeouts uint64
+	TxFIFOTimeouts      uint64
+	TxInitAborts        uint64
+	TxAborts            uint64
+	TxAbortTimeouts     uint64
+}
 
 // Port represents a CPU port module.
 type Port struct {
@@ -55,10 +79,26 @@ type Port struct {
 	// FID represents the VLAN filtering identifier
 	FID int
 
+	rxMu sync.Mutex
+	txMu sync.Mutex
+
+	rxTruncated         atomic.Uint64
+	rxAborted           atomic.Uint64
+	rxEmpty             atomic.Uint64
+	rxOversized         atomic.Uint64
+	rxInvalid           atomic.Uint64
+	rxShortHeader       atomic.Uint64
+	txWatermarkTimeouts atomic.Uint64
+	txFIFOTimeouts      atomic.Uint64
+	txInitAborts        atomic.Uint64
+	txAborts            atomic.Uint64
+	txAbortTimeouts     atomic.Uint64
+
 	// control registers
-	xtr_rd   uint32
-	inj_ctrl uint32
-	inj_wr   uint32
+	xtr_rd     uint32
+	inj_ctrl   uint32
+	inj_wr     uint32
+	inj_status uint32
 }
 
 // Init initializes a CPU port module.
@@ -69,6 +109,12 @@ func (p *Port) Init() (err error) {
 	if p.Queue == 0 {
 		return errors.New("invalid port instance")
 	}
+
+	if p.Group < 0 || p.Group > 1 {
+		return errors.New("invalid port group")
+	}
+
+	p.resetErrorCounters()
 
 	if p.MAC == nil {
 		p.MAC = make([]byte, 6)
@@ -94,14 +140,56 @@ func (p *Port) Init() (err error) {
 	p.xtr_rd = p.Queue + XTR_RD + groupOffset
 	p.inj_ctrl = p.Queue + INJ_CTRL + groupOffset
 	p.inj_wr = p.Queue + INJ_WR + groupOffset
+	p.inj_status = p.Queue + INJ_STATUS
 
 	// set manual injection/extraction for CPU queue
 	reg.Write(p.Queue+INJ_GRP_CFG+groupOffset, 1<<CFG_MODE|1<<CFG_BYTE_SWAP)
 	reg.Write(p.Queue+XTR_GRP_CFG+groupOffset, 1<<CFG_MODE|1<<CFG_STATUS_WORD_POS|1<<CFG_BYTE_SWAP)
 	reg.Write(p.Queue+XTR_FRM_PRUNING+groupOffset, 0)
 
+	// abort stale frame
+	if reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
+		p.txInitAborts.Add(1)
+
+		if !p.abortInjection() {
+			return errors.New("injection abort failed")
+		}
+	}
+
 	// add physical address to MAC table
 	p.SetMAC(p.MAC)
+
+	return
+}
+
+func (p *Port) resetErrorCounters() {
+	p.rxTruncated.Store(0)
+	p.rxAborted.Store(0)
+	p.rxEmpty.Store(0)
+	p.rxOversized.Store(0)
+	p.rxInvalid.Store(0)
+	p.rxShortHeader.Store(0)
+	p.txWatermarkTimeouts.Store(0)
+	p.txFIFOTimeouts.Store(0)
+	p.txInitAborts.Store(0)
+	p.txAborts.Store(0)
+	p.txAbortTimeouts.Store(0)
+}
+
+// ErrorCounters returns frame path errors since the most recent call to
+// [Port.Init].
+func (p *Port) ErrorCounters() (counters ErrorCounters) {
+	counters.RxTruncated = p.rxTruncated.Load()
+	counters.RxAborted = p.rxAborted.Load()
+	counters.RxEmpty = p.rxEmpty.Load()
+	counters.RxOversized = p.rxOversized.Load()
+	counters.RxInvalid = p.rxInvalid.Load()
+	counters.RxShortHeader = p.rxShortHeader.Load()
+	counters.TxWatermarkTimeouts = p.txWatermarkTimeouts.Load()
+	counters.TxFIFOTimeouts = p.txFIFOTimeouts.Load()
+	counters.TxInitAborts = p.txInitAborts.Load()
+	counters.TxAborts = p.txAborts.Load()
+	counters.TxAbortTimeouts = p.txAbortTimeouts.Load()
 
 	return
 }
@@ -148,8 +236,10 @@ func (p *Port) recv(buf []byte) (eof bool, unused int, err error) {
 		unused = 3
 	case RD_EOF_TRUNCATED:
 		p.read()
+		p.rxTruncated.Add(1)
 		err = errors.New("truncated frame")
 	case RD_EOF_ABORTED:
+		p.rxAborted.Add(1)
 		err = errors.New("aborted frame")
 	case RD_ESCAPE:
 		binary.LittleEndian.PutUint32(buf, p.read())
@@ -162,6 +252,9 @@ func (p *Port) recv(buf []byte) (eof bool, unused int, err error) {
 
 // Receive receives a single Ethernet frame from a port module.
 func (p *Port) Receive(buf []byte) (n int, err error) {
+	p.rxMu.Lock()
+	defer p.rxMu.Unlock()
+
 	if !reg.Get(p.Queue+XTR_DATA_PRESENT, p.Group) {
 		return
 	}
@@ -176,6 +269,7 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 		case recvErr != nil:
 			err = recvErr
 		case eof:
+			p.rxShortHeader.Add(1)
 			err = errors.New("short frame header")
 		}
 
@@ -203,6 +297,7 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 		if eof {
 			if unused > padded {
 				n = 0
+				p.rxInvalid.Add(1)
 				err = errors.New("invalid frame length")
 				return
 			}
@@ -212,8 +307,10 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 			switch {
 			case length == 0:
 				n = 0
+				p.rxEmpty.Add(1)
 				err = errors.New("empty frame")
 			case length > len(buf):
+				p.rxOversized.Add(1)
 				err = errors.New("frame exceeds receive buffer")
 			default:
 				n = length
@@ -233,20 +330,129 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 	}
 }
 
+func (p *Port) waitForInjection() (err error) {
+	group := uint32(1 << p.Group)
+	fifoReady := group << INJ_STATUS_FIFO_RDY
+	watermarkReached := group << INJ_STATUS_WMARK_REACHED
+	var deadline time.Time
+
+	for {
+		status := reg.Read(p.inj_status)
+		watermarked := status&watermarkReached != 0
+
+		if !watermarked && status&fifoReady != 0 {
+			return
+		}
+
+		now := time.Now()
+		if deadline.IsZero() {
+			deadline = now.Add(injectionTimeout)
+		} else if !now.Before(deadline) {
+			if watermarked {
+				p.txWatermarkTimeouts.Add(1)
+				return errors.New("injection watermark reached")
+			}
+
+			p.txFIFOTimeouts.Add(1)
+			return errors.New("injection FIFO not ready")
+		}
+
+		if watermarked {
+			time.Sleep(injectionPollInterval)
+		} else {
+			runtime.Gosched()
+		}
+	}
+}
+
+func (p *Port) write(val uint32) (err error) {
+	if reg.Get(p.inj_status, INJ_STATUS_FIFO_RDY+p.Group) {
+		reg.Write(p.inj_wr, val)
+		return
+	}
+
+	deadline := time.Now().Add(injectionTimeout)
+
+	for !reg.Get(p.inj_status, INJ_STATUS_FIFO_RDY+p.Group) {
+		if !time.Now().Before(deadline) {
+			p.txFIFOTimeouts.Add(1)
+			return errors.New("injection FIFO not ready")
+		}
+
+		runtime.Gosched()
+	}
+
+	reg.Write(p.inj_wr, val)
+	return
+}
+
+func (p *Port) abortInjection() (complete bool) {
+	reg.Set(p.inj_ctrl, CTRL_ABORT)
+
+	deadline := time.Now().Add(injectionTimeout)
+	for reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
+		if !time.Now().Before(deadline) {
+			p.txAbortTimeouts.Add(1)
+			return
+		}
+
+		runtime.Gosched()
+	}
+
+	return true
+}
+
 // Transmit transmits a single Ethernet frame to a port module.
 func (p *Port) Transmit(buf []byte) (err error) {
+	p.txMu.Lock()
+	defer p.txMu.Unlock()
+
+	if err = p.waitForInjection(); err != nil {
+		return
+	}
+
 	valid := len(buf) % 4
+	if len(buf) < minimumFrameSize {
+		valid = 0
+	}
 
 	// signal Start Of Frame
 	reg.Set(p.inj_ctrl, CTRL_SOF)
 
-	// pad to word size
-	if r := len(buf) % 4; r != 0 {
-		buf = append(buf, make([]byte, 4-r)...)
+	defer func() {
+		if err != nil {
+			p.txAborts.Add(1)
+			p.abortInjection()
+		}
+	}()
+
+	var scratch [4]byte
+	written := 0
+
+	for len(buf)-written >= len(scratch) {
+		if err = p.write(binary.LittleEndian.Uint32(buf[written:])); err != nil {
+			return
+		}
+
+		written += len(scratch)
 	}
 
-	for i := 0; i < len(buf); i += 4 {
-		reg.Write(p.inj_wr, binary.LittleEndian.Uint32(buf[i:]))
+	if written < len(buf) {
+		copy(scratch[:], buf[written:])
+
+		if err = p.write(binary.LittleEndian.Uint32(scratch[:])); err != nil {
+			return
+		}
+
+		written += len(scratch)
+	}
+
+	for written < minimumFrameSize {
+		if err = p.write(0); err != nil {
+			return
+		}
+
+		written += len(scratch)
 	}
 
 	// set valid bytes of last word
@@ -256,7 +462,6 @@ func (p *Port) Transmit(buf []byte) (err error) {
 	reg.Set(p.inj_ctrl, CTRL_EOF)
 
 	// add dummy CRC
-	reg.Write(p.inj_wr, 0)
-
+	err = p.write(0)
 	return
 }

--- a/soc/microchip/devcpu/port.go
+++ b/soc/microchip/devcpu/port.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"runtime"
 	"sync"
 
 	"github.com/usbarmory/tamago/internal/reg"
@@ -95,8 +96,9 @@ func (p *Port) Init() (err error) {
 	p.inj_wr = p.Queue + INJ_WR + groupOffset
 
 	// set manual injection/extraction for CPU queue
-	reg.SetN(p.Queue+INJ_GRP_CFG+groupOffset, CFG_MODE, 0b11, 1)
-	reg.SetN(p.Queue+XTR_GRP_CFG+groupOffset, CFG_MODE, 0b11, 1)
+	reg.Write(p.Queue+INJ_GRP_CFG+groupOffset, 1<<CFG_MODE|1<<CFG_BYTE_SWAP)
+	reg.Write(p.Queue+XTR_GRP_CFG+groupOffset, 1<<CFG_MODE|1<<CFG_STATUS_WORD_POS|1<<CFG_BYTE_SWAP)
+	reg.Write(p.Queue+XTR_FRM_PRUNING+groupOffset, 0)
 
 	// add physical address to MAC table
 	p.SetMAC(p.MAC)
@@ -119,19 +121,43 @@ func (p *Port) SetMAC(mac net.HardwareAddr) {
 	p.MAC = mac
 }
 
-func (p *Port) recv(buf []byte) (ok bool) {
-	switch val := reg.Read(p.xtr_rd); val {
-	case RD_EOF_UNUSED_0, RD_EOF_UNUSED_1, RD_EOF_UNUSED_2, RD_EOF_UNUSED_3:
-		return false
-	case RD_EOF_TRUNCATED, RD_EOF_ABORTED, RD_ESCAPE:
-		return false
-	case RD_NOT_READY:
-		return false
+func (p *Port) read() (val uint32) {
+	for {
+		if val = reg.Read(p.xtr_rd); val != RD_NOT_READY {
+			return
+		}
+
+		runtime.Gosched()
+	}
+}
+
+func (p *Port) recv(buf []byte) (eof bool, unused int, err error) {
+	val := p.read()
+
+	switch val {
+	case RD_EOF_UNUSED_0:
+		eof = true
+	case RD_EOF_UNUSED_1:
+		eof = true
+		unused = 1
+	case RD_EOF_UNUSED_2:
+		eof = true
+		unused = 2
+	case RD_EOF_UNUSED_3:
+		eof = true
+		unused = 3
+	case RD_EOF_TRUNCATED:
+		p.read()
+		err = errors.New("truncated frame")
+	case RD_EOF_ABORTED:
+		err = errors.New("aborted frame")
+	case RD_ESCAPE:
+		binary.LittleEndian.PutUint32(buf, p.read())
 	default:
 		binary.LittleEndian.PutUint32(buf, val)
 	}
 
-	return true
+	return
 }
 
 // Receive receives a single Ethernet frame from a port module.
@@ -140,37 +166,77 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 		return
 	}
 
+	var scratch [4]byte
+
 	// skip internal frame header
 	for i := 0; i < p.HeaderLength; i += 4 {
-		reg.Read(p.xtr_rd)
-	}
+		eof, _, recvErr := p.recv(scratch[:])
 
-	length := len(buf)
-	r := length % 4
+		switch {
+		case recvErr != nil:
+			err = recvErr
+		case eof:
+			err = errors.New("short frame header")
+		}
 
-	for i := 0; i < length-r; i += 4 {
-		if p.recv(buf[i:]) {
-			n += 4
-		} else {
+		if err != nil {
 			return
 		}
 	}
 
-	if r > 0 {
-		if b := make([]byte, 4); p.recv(b) {
-			copy(buf[length-r:], b)
-			n += r
+	padded := 0
 
-			// reach EOF
-			p.recv(b)
+	for {
+		dst := scratch[:]
+		direct := len(buf)-n >= len(scratch)
+
+		if direct {
+			dst = buf[n : n+len(scratch)]
+		}
+
+		eof, unused, recvErr := p.recv(dst)
+		if recvErr != nil {
+			err = recvErr
+			return
+		}
+
+		if eof {
+			if unused > padded {
+				n = 0
+				err = errors.New("invalid frame length")
+				return
+			}
+
+			length := padded - unused
+
+			switch {
+			case length == 0:
+				n = 0
+				err = errors.New("empty frame")
+			case length > len(buf):
+				err = errors.New("frame exceeds receive buffer")
+			default:
+				n = length
+			}
+
+			return
+		}
+
+		padded += len(scratch)
+
+		switch {
+		case direct:
+			n += len(scratch)
+		case n < len(buf):
+			n += copy(buf[n:], scratch[:])
 		}
 	}
-
-	return
 }
 
 // Transmit transmits a single Ethernet frame to a port module.
 func (p *Port) Transmit(buf []byte) (err error) {
+	valid := len(buf) % 4
+
 	// signal Start Of Frame
 	reg.Set(p.inj_ctrl, CTRL_SOF)
 
@@ -184,7 +250,7 @@ func (p *Port) Transmit(buf []byte) (err error) {
 	}
 
 	// set valid bytes of last word
-	reg.SetN(p.inj_ctrl, CTRL_VLD_BYTES, 0b11, uint32(len(buf)%4))
+	reg.SetN(p.inj_ctrl, CTRL_VLD_BYTES, 0b11, uint32(valid))
 
 	// signal End Of Frame
 	reg.Set(p.inj_ctrl, CTRL_EOF)

--- a/soc/microchip/devcpu/port.go
+++ b/soc/microchip/devcpu/port.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/usbarmory/tamago/internal/reg"
@@ -31,15 +30,15 @@ import (
 )
 
 const (
-	injectionPollInterval = 1 * time.Millisecond
-	injectionTimeout      = 1 * time.Second
-	minimumFrameSize      = 60
+	ExtractionTimeout     = 1 * time.Second
+	InjectionTimeout      = 1 * time.Second
+	InjectionPollInterval = 1 * time.Millisecond
+	MinimumFrameSize      = 60
 )
 
-// ErrorCounters represents frame path errors since the most recent call to
-// [Port.Init].
-type ErrorCounters struct {
+type Stats struct {
 	RxTruncated         uint64
+	RxFIFOTimeouts      uint64
 	RxAborted           uint64
 	RxEmpty             uint64
 	RxOversized         uint64
@@ -47,7 +46,6 @@ type ErrorCounters struct {
 	RxShortHeader       uint64
 	TxWatermarkTimeouts uint64
 	TxFIFOTimeouts      uint64
-	TxInitAborts        uint64
 	TxAborts            uint64
 	TxAbortTimeouts     uint64
 }
@@ -79,20 +77,11 @@ type Port struct {
 	// FID represents the VLAN filtering identifier
 	FID int
 
+	// Statistics
+	Stats Stats
+
 	rxMu sync.Mutex
 	txMu sync.Mutex
-
-	rxTruncated         atomic.Uint64
-	rxAborted           atomic.Uint64
-	rxEmpty             atomic.Uint64
-	rxOversized         atomic.Uint64
-	rxInvalid           atomic.Uint64
-	rxShortHeader       atomic.Uint64
-	txWatermarkTimeouts atomic.Uint64
-	txFIFOTimeouts      atomic.Uint64
-	txInitAborts        atomic.Uint64
-	txAborts            atomic.Uint64
-	txAbortTimeouts     atomic.Uint64
 
 	// control registers
 	xtr_rd     uint32
@@ -114,7 +103,7 @@ func (p *Port) Init() (err error) {
 		return errors.New("invalid port group")
 	}
 
-	p.resetErrorCounters()
+	p.Stats = Stats{}
 
 	if p.MAC == nil {
 		p.MAC = make([]byte, 6)
@@ -148,48 +137,12 @@ func (p *Port) Init() (err error) {
 	reg.Write(p.Queue+XTR_FRM_PRUNING+groupOffset, 0)
 
 	// abort stale frame
-	if reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
-		p.txInitAborts.Add(1)
-
-		if !p.abortInjection() {
-			return errors.New("injection abort failed")
-		}
+	if !p.abortInjection() {
+		return errors.New("injection abort failed")
 	}
 
 	// add physical address to MAC table
 	p.SetMAC(p.MAC)
-
-	return
-}
-
-func (p *Port) resetErrorCounters() {
-	p.rxTruncated.Store(0)
-	p.rxAborted.Store(0)
-	p.rxEmpty.Store(0)
-	p.rxOversized.Store(0)
-	p.rxInvalid.Store(0)
-	p.rxShortHeader.Store(0)
-	p.txWatermarkTimeouts.Store(0)
-	p.txFIFOTimeouts.Store(0)
-	p.txInitAborts.Store(0)
-	p.txAborts.Store(0)
-	p.txAbortTimeouts.Store(0)
-}
-
-// ErrorCounters returns frame path errors since the most recent call to
-// [Port.Init].
-func (p *Port) ErrorCounters() (counters ErrorCounters) {
-	counters.RxTruncated = p.rxTruncated.Load()
-	counters.RxAborted = p.rxAborted.Load()
-	counters.RxEmpty = p.rxEmpty.Load()
-	counters.RxOversized = p.rxOversized.Load()
-	counters.RxInvalid = p.rxInvalid.Load()
-	counters.RxShortHeader = p.rxShortHeader.Load()
-	counters.TxWatermarkTimeouts = p.txWatermarkTimeouts.Load()
-	counters.TxFIFOTimeouts = p.txFIFOTimeouts.Load()
-	counters.TxInitAborts = p.txInitAborts.Load()
-	counters.TxAborts = p.txAborts.Load()
-	counters.TxAbortTimeouts = p.txAbortTimeouts.Load()
 
 	return
 }
@@ -209,18 +162,68 @@ func (p *Port) SetMAC(mac net.HardwareAddr) {
 	p.MAC = mac
 }
 
-func (p *Port) read() (val uint32) {
-	for {
-		if val = reg.Read(p.xtr_rd); val != RD_NOT_READY {
+func (p *Port) abortInjection() (complete bool) {
+	reg.Set(p.inj_ctrl, CTRL_ABORT)
+	deadline := time.Now().Add(InjectionTimeout)
+
+	for reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
+		if !time.Now().Before(deadline) {
+			p.Stats.TxAbortTimeouts++
 			return
 		}
 
 		runtime.Gosched()
 	}
+
+	return true
+}
+
+func (p *Port) read() (val uint32, err error) {
+	var deadline time.Time
+
+	for val = reg.Read(p.xtr_rd); val == RD_NOT_READY; val = reg.Read(p.xtr_rd) {
+		if deadline.IsZero() {
+			deadline = time.Now().Add(ExtractionTimeout)
+		}
+
+		if !time.Now().Before(deadline) {
+			p.Stats.RxFIFOTimeouts++
+			return 0, errors.New("extraction FIFO not ready")
+		}
+
+		runtime.Gosched()
+	}
+
+	return
+}
+
+func (p *Port) write(val uint32) (err error) {
+	var deadline time.Time
+
+	for !reg.Get(p.inj_status, INJ_STATUS_FIFO_RDY+p.Group) {
+		if deadline.IsZero() {
+			deadline = time.Now().Add(InjectionTimeout)
+		}
+
+		if !time.Now().Before(deadline) {
+			p.Stats.TxFIFOTimeouts++
+			return errors.New("injection FIFO not ready")
+		}
+
+		runtime.Gosched()
+	}
+
+	reg.Write(p.inj_wr, val)
+
+	return
 }
 
 func (p *Port) recv(buf []byte) (eof bool, unused int, err error) {
-	val := p.read()
+	val, err := p.read()
+
+	if err != nil {
+		return
+	}
 
 	switch val {
 	case RD_EOF_UNUSED_0:
@@ -236,13 +239,15 @@ func (p *Port) recv(buf []byte) (eof bool, unused int, err error) {
 		unused = 3
 	case RD_EOF_TRUNCATED:
 		p.read()
-		p.rxTruncated.Add(1)
+		p.Stats.RxTruncated++
 		err = errors.New("truncated frame")
 	case RD_EOF_ABORTED:
-		p.rxAborted.Add(1)
+		p.Stats.RxAborted++
 		err = errors.New("aborted frame")
 	case RD_ESCAPE:
-		binary.LittleEndian.PutUint32(buf, p.read())
+		if val, err = p.read(); err == nil {
+			binary.LittleEndian.PutUint32(buf, val)
+		}
 	default:
 		binary.LittleEndian.PutUint32(buf, val)
 	}
@@ -259,22 +264,19 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 		return
 	}
 
+	// rx FIFO reads are 32-bits of frame data
 	var scratch [4]byte
 
 	// skip internal frame header
 	for i := 0; i < p.HeaderLength; i += 4 {
-		eof, _, recvErr := p.recv(scratch[:])
+		eof, _, err := p.recv(scratch[:])
 
 		switch {
-		case recvErr != nil:
-			err = recvErr
+		case err != nil:
+			return 0, err
 		case eof:
-			p.rxShortHeader.Add(1)
-			err = errors.New("short frame header")
-		}
-
-		if err != nil {
-			return
+			p.Stats.RxShortHeader++
+			return 0, errors.New("short frame header")
 		}
 	}
 
@@ -282,59 +284,45 @@ func (p *Port) Receive(buf []byte) (n int, err error) {
 
 	for {
 		dst := scratch[:]
-		direct := len(buf)-n >= len(scratch)
 
-		if direct {
-			dst = buf[n : n+len(scratch)]
+		if len(buf)-padded >= len(scratch) {
+			dst = buf[padded : padded+len(scratch)]
 		}
 
-		eof, unused, recvErr := p.recv(dst)
-		if recvErr != nil {
-			err = recvErr
-			return
+		eof, unused, err := p.recv(dst)
+
+		if err != nil {
+			return 0, err
 		}
 
 		if eof {
 			if unused > padded {
-				n = 0
-				p.rxInvalid.Add(1)
-				err = errors.New("invalid frame length")
-				return
+				p.Stats.RxInvalid++
+				return 0, errors.New("invalid frame length")
 			}
 
-			length := padded - unused
-
-			switch {
+			switch length := padded - unused; {
 			case length == 0:
-				n = 0
-				p.rxEmpty.Add(1)
-				err = errors.New("empty frame")
+				p.Stats.RxEmpty++
+				return 0, errors.New("empty frame")
 			case length > len(buf):
-				p.rxOversized.Add(1)
-				err = errors.New("frame exceeds receive buffer")
+				p.Stats.RxOversized++
+				return n, errors.New("frame exceeds receive buffer")
 			default:
-				n = length
+				return length, nil
 			}
-
-			return
 		}
 
 		padded += len(scratch)
-
-		switch {
-		case direct:
-			n += len(scratch)
-		case n < len(buf):
-			n += copy(buf[n:], scratch[:])
-		}
 	}
 }
 
 func (p *Port) waitForInjection() (err error) {
+	var deadline time.Time
+
 	group := uint32(1 << p.Group)
 	fifoReady := group << INJ_STATUS_FIFO_RDY
 	watermarkReached := group << INJ_STATUS_WMARK_REACHED
-	var deadline time.Time
 
 	for {
 		status := reg.Read(p.inj_status)
@@ -345,61 +333,25 @@ func (p *Port) waitForInjection() (err error) {
 		}
 
 		now := time.Now()
+
 		if deadline.IsZero() {
-			deadline = now.Add(injectionTimeout)
+			deadline = now.Add(InjectionTimeout)
 		} else if !now.Before(deadline) {
 			if watermarked {
-				p.txWatermarkTimeouts.Add(1)
+				p.Stats.TxWatermarkTimeouts++
 				return errors.New("injection watermark reached")
 			}
 
-			p.txFIFOTimeouts.Add(1)
+			p.Stats.TxFIFOTimeouts++
 			return errors.New("injection FIFO not ready")
 		}
 
 		if watermarked {
-			time.Sleep(injectionPollInterval)
+			time.Sleep(InjectionPollInterval)
 		} else {
 			runtime.Gosched()
 		}
 	}
-}
-
-func (p *Port) write(val uint32) (err error) {
-	if reg.Get(p.inj_status, INJ_STATUS_FIFO_RDY+p.Group) {
-		reg.Write(p.inj_wr, val)
-		return
-	}
-
-	deadline := time.Now().Add(injectionTimeout)
-
-	for !reg.Get(p.inj_status, INJ_STATUS_FIFO_RDY+p.Group) {
-		if !time.Now().Before(deadline) {
-			p.txFIFOTimeouts.Add(1)
-			return errors.New("injection FIFO not ready")
-		}
-
-		runtime.Gosched()
-	}
-
-	reg.Write(p.inj_wr, val)
-	return
-}
-
-func (p *Port) abortInjection() (complete bool) {
-	reg.Set(p.inj_ctrl, CTRL_ABORT)
-
-	deadline := time.Now().Add(injectionTimeout)
-	for reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
-		if !time.Now().Before(deadline) {
-			p.txAbortTimeouts.Add(1)
-			return
-		}
-
-		runtime.Gosched()
-	}
-
-	return true
 }
 
 // Transmit transmits a single Ethernet frame to a port module.
@@ -412,7 +364,9 @@ func (p *Port) Transmit(buf []byte) (err error) {
 	}
 
 	valid := len(buf) % 4
-	if len(buf) < minimumFrameSize {
+	written := 0
+
+	if len(buf) < MinimumFrameSize {
 		valid = 0
 	}
 
@@ -421,13 +375,13 @@ func (p *Port) Transmit(buf []byte) (err error) {
 
 	defer func() {
 		if err != nil {
-			p.txAborts.Add(1)
+			p.Stats.TxAborts++
 			p.abortInjection()
 		}
 	}()
 
+	// tx FIFO reads are 32-bits of frame data
 	var scratch [4]byte
-	written := 0
 
 	for len(buf)-written >= len(scratch) {
 		if err = p.write(binary.LittleEndian.Uint32(buf[written:])); err != nil {
@@ -447,7 +401,7 @@ func (p *Port) Transmit(buf []byte) (err error) {
 		written += len(scratch)
 	}
 
-	for written < minimumFrameSize {
+	for written < MinimumFrameSize {
 		if err = p.write(0); err != nil {
 			return
 		}
@@ -463,5 +417,6 @@ func (p *Port) Transmit(buf []byte) (err error) {
 
 	// add dummy CRC
 	err = p.write(0)
+
 	return
 }


### PR DESCRIPTION
Handle LAN969x extraction status words without losing FIFO alignment. Serialize manual transfers, bound injection and abort waits, correctly pad short frames, reset stale D29 token state, and expose categorized error counters.

Validated on LAN969x with concurrent ICMP, HTTP, and SSH traffic.