### PR TITLE
microchip: format lan969x and otpc code

### DIFF
--- a/soc/microchip/lan969x/irq.go
+++ b/soc/microchip/lan969x/irq.go
@@ -14,7 +14,7 @@ import (
 
 // Interrupt controller registers
 const (
-	INTR              = 0x128
+	INTR             = 0x128
 	INTR_STICKY_BASE = INTR + 0x40
 	INTR_ENA_BASE    = INTR + 0x60
 )

--- a/soc/microchip/otpc/otpc.go
+++ b/soc/microchip/otpc/otpc.go
@@ -133,7 +133,7 @@ func (hw *OTPC) Read(off int, b []byte) (err error) {
 	hw.Lock()
 	defer hw.Unlock()
 
-	if off + len(b) >= hw.Size {
+	if off+len(b) >= hw.Size {
 		return errors.New("address out of range")
 	}
 
@@ -161,7 +161,7 @@ func (hw *OTPC) Blow(off int, b []byte) (err error) {
 	hw.Lock()
 	defer hw.Unlock()
 
-	if off + len(b) >= hw.Size {
+	if off+len(b) >= hw.Size {
 		return errors.New("address out of range")
 	}
 
@@ -169,7 +169,7 @@ func (hw *OTPC) Blow(off int, b []byte) (err error) {
 	defer hw.power(false)
 
 	for i := range b {
-		if err = hw.write(uint32(off + i), b[i]); err != nil {
+		if err = hw.write(uint32(off+i), b[i]); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Apply gofmt to the LAN969x interrupt register definitions and OTPC offset expressions.