### PR TITLE
move Ethernet PHY drivers to individual sub-packages

### DIFF
--- a/board/microchip/lan9696evb/const.go
+++ b/board/microchip/lan9696evb/const.go
@@ -122,37 +122,6 @@ const (
 	INJ_FORMAT_CFG  = 2
 )
 
-// PHY registers
-const (
-	PHY_ADDR = 0x03
-
-	PHY_CTRL        = 0x00
-	PHY_STATUS      = 0x01
-	PHY_ANEG_ADV    = 0x04
-	PHY_ANEG_LPA    = 0x05
-	PHY_1000_CTRL   = 0x09
-	PHY_1000_STATUS = 0x0a
-
-	CTRL_RESET        = 15
-	CTRL_SPEED0       = 13
-	CTRL_ANEG         = 12
-	CTRL_ANEG_RESTART = 9
-	CTRL_DUPLEX       = 8
-	CTRL_SPEED1       = 6
-
-	STATUS_LINK          = 2
-	STATUS_ANEG_COMPLETE = 5
-
-	ANEG_ADV_10_HALF   = 1 << 5
-	ANEG_ADV_10_FULL   = 1 << 6
-	ANEG_ADV_100_HALF  = 1 << 7
-	ANEG_ADV_100_FULL  = 1 << 8
-	ANEG_ADV_1000_HALF = 1 << 8
-	ANEG_ADV_1000_FULL = 1 << 9
-	ANEG_LPA_1000_HALF = 1 << 10
-	ANEG_LPA_1000_FULL = 1 << 11
-)
-
 // XMII registers
 const (
 	XMIICFG0 = lan969x.HSIO_BASE + 0x74

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -59,15 +59,13 @@ func enablePort() (err error) {
 	initGPIO(9, 1)
 	initGPIO(10, 1)
 
-	phy := &lan8840.PHY{
-		Address: PHY_ADDR,
-		MIIM:    lan969x.MIIM0,
-	}
+	phy := &lan8840.PHY{}
+	miim := lan969x.MIIM0
 
-	phy.MIIM.Init()
+	miim.Init()
 
 	// initialize LAN8840 PHY
-	if err = phy.Init(); err != nil {
+	if err = phy.Init(PHY_ADDR, miim); err != nil {
 		return
 	}
 

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -62,7 +62,9 @@ func enablePort() (err error) {
 	phy := &lan8840.PHY{}
 	miim := lan969x.MIIM0
 
-	miim.Init()
+	if err = miim.Init(); err != nil {
+		return
+	}
 
 	// initialize LAN8840 PHY
 	if err = phy.Init(PHY_ADDR, miim); err != nil {

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -10,25 +10,18 @@ package lan9696evb
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/usbarmory/tamago/bits"
 	"github.com/usbarmory/tamago/internal/reg"
+	"github.com/usbarmory/tamago/phy/microchip/lan8840"
 	"github.com/usbarmory/tamago/soc/microchip/devcpu"
 	"github.com/usbarmory/tamago/soc/microchip/lan969x"
-	"github.com/usbarmory/tamago/soc/microchip/miim"
 )
 
 const (
+	PHY_ADDR            = 0x03
 	MAC_FID             = 1
 	ManagementPortIndex = PORT29
-)
-
-var (
-	// WaitTimeout represents the timeout for PHY register writes
-	WaitTimeout = 10 * time.Second
-	// PollInterval represents the delay between PHY register write attempts
-	PollInterval = 10 * time.Millisecond
 )
 
 // On the LAN969x 24-port EVB the management network interface is port D29,
@@ -49,34 +42,6 @@ func resetInjectionFlowControl(port uint32) {
 }
 
 func enablePort() (err error) {
-	// init LAN8840 PHY
-	speed, err := initPHY(lan969x.MIIM0)
-
-	if err != nil {
-		return
-	}
-
-	// init MAC controller
-	if err = initRGMII(speed); err != nil {
-		return
-	}
-
-	// init VLAN on physical and CPU port
-	initVLAN(PORT29)
-	initVLAN(PORT30)
-
-	// init capture on CPU port 0 (D30)
-	initCapture(PORT_CFG30)
-
-	// reset injection flow control
-	resetInjectionFlowControl(PORT29)
-
-	return nil
-}
-
-func initPHY(miim *miim.MIIM) (speed int, err error) {
-	var control uint16
-
 	// Table 2-7: GPIO alternate function assignments
 	//
 	// GPIO_9:  ALT1 - MIIM0_MDC
@@ -84,94 +49,34 @@ func initPHY(miim *miim.MIIM) (speed int, err error) {
 	lan969x.GPIO.Function(9, 1)
 	lan969x.GPIO.Function(10, 1)
 
-	miim.Init()
+	phy := &lan8840.PHY{
+		Address: PHY_ADDR,
+		MIIM:    lan969x.MIIM0,
+	}
 
-	// software reset
-	if err = miim.WritePHYRegister(PHY_ADDR, PHY_CTRL, (1 << CTRL_RESET)); err != nil {
+	phy.MIIM.Init()
+
+	// initialize LAN8840 PHY
+	if err = phy.Init(); err != nil {
 		return
 	}
 
-	if control, err = waitPHYRegister(miim, PHY_CTRL, 1<<CTRL_RESET, 0); err != nil {
-		return 0, fmt.Errorf("could not reset PHY, %v", err)
-	}
-
-	// enable and restart auto-negotiation
-	control |= (1 << CTRL_ANEG) | (1 << CTRL_ANEG_RESTART)
-
-	if err = miim.WritePHYRegister(PHY_ADDR, PHY_CTRL, control); err != nil {
+	// initialize MAC controller
+	if err = initRGMII(phy.Speed()); err != nil {
 		return
 	}
 
-	statusMask := uint16((1 << STATUS_LINK) | (1 << STATUS_ANEG_COMPLETE))
+	// initialize VLAN on physical and CPU port
+	initVLAN(PORT29)
+	initVLAN(PORT30)
 
-	if _, err = waitPHYRegister(miim, PHY_STATUS, statusMask, statusMask); err != nil {
-		return 0, fmt.Errorf("auto-negotiation status error, %w", err)
-	}
+	// initialize capture on CPU port 0 (D30)
+	initCapture(PORT_CFG30)
 
-	return negotiatedPHYSpeed(miim)
-}
+	// reset injection flow control
+	resetInjectionFlowControl(PORT29)
 
-func waitPHYRegister(miim *miim.MIIM, address int, mask uint16, value uint16) (data uint16, err error) {
-	deadline := time.Now().Add(WaitTimeout)
-
-	for {
-		if data, err = miim.ReadPHYRegister(PHY_ADDR, address); err != nil {
-			return
-		}
-
-		if data&mask == value {
-			return
-		}
-
-		if time.Now().After(deadline) {
-			return 0, fmt.Errorf("timed out waiting for PHY register %#x", address)
-		}
-
-		time.Sleep(PollInterval)
-	}
-}
-
-func negotiatedPHYSpeed(miim *miim.MIIM) (speed int, err error) {
-	var local, partner uint16
-
-	if local, err = miim.ReadPHYRegister(PHY_ADDR, PHY_1000_CTRL); err != nil {
-		return 0, fmt.Errorf("could not read 1000BASE-T control register, %v", err)
-	}
-
-	if partner, err = miim.ReadPHYRegister(PHY_ADDR, PHY_1000_STATUS); err != nil {
-		return 0, fmt.Errorf("could not read 1000BASE-T status register, %v", err)
-	}
-
-	if local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0 {
-		return 1000, nil
-	}
-
-	if local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0 {
-		return 0, fmt.Errorf("unsupported half-duplex management link")
-	}
-
-	if local, err = miim.ReadPHYRegister(PHY_ADDR, PHY_ANEG_ADV); err != nil {
-		return 0, fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
-	}
-
-	if partner, err = miim.ReadPHYRegister(PHY_ADDR, PHY_ANEG_LPA); err != nil {
-		return 0, fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
-	}
-
-	common := local & partner
-
-	switch {
-	case common&ANEG_ADV_100_FULL != 0:
-		speed = 100
-	case common&ANEG_ADV_100_HALF != 0:
-		err = fmt.Errorf("unsupported half-duplex management link")
-	case common&(ANEG_ADV_10_FULL|ANEG_ADV_10_HALF) != 0:
-		err = fmt.Errorf("unsupported 10 Mbps management link")
-	default:
-		err = fmt.Errorf("management PHY has no common advertised mode")
-	}
-
-	return
+	return nil
 }
 
 func initRGMII(speed int) (err error) {

--- a/board/nxp/mx6ullevk/enet.go
+++ b/board/nxp/mx6ullevk/enet.go
@@ -11,29 +11,14 @@ package mx6ullevk
 import (
 	"errors"
 
+	"github.com/usbarmory/tamago/phy/microchip/ksz8081"
 	"github.com/usbarmory/tamago/soc/nxp/enet"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/iomuxc"
 )
 
-// Ethernet PHY configuration constants.
-//
 // On the MCIMX6ULL-EVK the ENET MACs are each connected to an KSZ8081RNB PHY,
 // this board package configures them at 100 Mbps / Full-duplex mode.
-const (
-	KSZ_CTRL    = 0x00
-	CTRL_RESET  = 15
-	CTRL_SPEED  = 13
-	CTRL_DUPLEX = 8
-
-	KSZ_INT = 0x1b
-
-	KSZ_PHYCTRL2  = 0x1f
-	CTRL2_HP_MDIX = 15
-	CTRL2_RMII    = 7
-	CTRL2_LED     = 4
-)
-
 const (
 	// ENET1 MUX
 	IOMUXC_SW_MUX_CTL_PAD_ENET1_RX_DATA0 = 0x020e00c4
@@ -282,28 +267,23 @@ func configurePHY2Pads() {
 		0, IOMUX_ALT1, ctl100)
 }
 
+var phy *ksz8081.PHY
+
 func EnablePHY(eth *enet.ENET) error {
-	var pa int
+	phy = &ksz8081.PHY{
+		MIIM: eth,
+	}
 
 	switch eth.Index {
 	case 1:
-		pa = 2
 		configurePHY1Pads()
+		phy.Address = 2
 	case 2:
-		pa = 1
 		configurePHY2Pads()
+		phy.Address = 1
 	default:
 		return errors.New("invalid index")
 	}
 
-	// Software reset
-	eth.WritePHYRegister(pa, KSZ_CTRL, (1 << CTRL_RESET))
-	// HP Auto MDI/MDI-X mode, RMII 50MHz, LEDs: Activity/Link
-	eth.WritePHYRegister(pa, KSZ_PHYCTRL2, (1<<CTRL2_HP_MDIX)|(1<<CTRL2_RMII)|(1<<CTRL2_LED))
-	// 100 Mbps, Full-duplex
-	eth.WritePHYRegister(pa, KSZ_CTRL, (1<<CTRL_SPEED)|(1<<CTRL_DUPLEX))
-	// enable interrupts
-	eth.WritePHYRegister(pa, KSZ_INT, 0xff00)
-
-	return nil
+	return phy.EnableInterrupts()
 }

--- a/board/nxp/mx6ullevk/enet.go
+++ b/board/nxp/mx6ullevk/enet.go
@@ -269,20 +269,22 @@ func configurePHY2Pads() {
 
 var phy *ksz8081.PHY
 
-func EnablePHY(eth *enet.ENET) error {
-	phy = &ksz8081.PHY{
-		MIIM: eth,
-	}
+func EnablePHY(eth *enet.ENET) (err error) {
+	phy = &ksz8081.PHY{}
 
 	switch eth.Index {
 	case 1:
 		configurePHY1Pads()
-		phy.Address = 2
+		err = phy.Init(2, eth)
 	case 2:
 		configurePHY2Pads()
-		phy.Address = 1
+		err = phy.Init(1, eth)
 	default:
 		return errors.New("invalid index")
+	}
+
+	if err != nil {
+		return
 	}
 
 	return phy.EnableInterrupts()

--- a/board/usbarmory/mk2/enet.go
+++ b/board/usbarmory/mk2/enet.go
@@ -9,6 +9,7 @@
 package mk2
 
 import (
+	"github.com/usbarmory/tamago/phy/ti/dp83825i"
 	"github.com/usbarmory/tamago/soc/nxp/enet"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/iomuxc"
@@ -57,38 +58,8 @@ const (
 
 	DAISY_ENET2_TX_CLK_ALT4     = 0b10
 	DAISY_ENET2_GPIO1_IO06_ALT0 = 0
-)
 
-// DP83825I PHY registers
-const (
 	PHY_ADDR = 0
-
-	DP_CTRL     = 0x00
-	CTRL_RESET  = 15
-	CTRL_SPEED  = 13
-	CTRL_ANEG   = 12
-	CTRL_DUPLEX = 8
-
-	DP_REGCR = 0xd
-	DP_ADDAR = 0xe
-
-	DP_RCSR      = 0x17
-	RCSR_RMII_CS = 7
-	RCSR_RX_BUF  = 0
-
-	DP_LEDCR1           = 0x18
-	LEDCR1_LINK_LED_DRV = 4
-	LEDCR1_LINK_LED_OFF = 1
-
-	DP_LEDCR2           = 0x469
-	LEDCR2_LED2_DRV_VAL = 5
-	LEDCR2_LED2_DRV_EN  = 4
-)
-
-// Table 22–9, MMD access control register bit definitions, 802.3-2008
-const (
-	MMD_FN_ADDR = 0b00
-	MMD_FN_DATA = 0b01
 )
 
 func init() {
@@ -193,15 +164,15 @@ func configurePHYPads() {
 		0, IOMUX_ALT1, ctl100)
 }
 
+var phy *dp83825i.PHY
+
 func EnablePHY(eth *enet.ENET) error {
 	configurePHYPads()
 
-	// software reset
-	eth.WritePHYRegister(PHY_ADDR, DP_CTRL, (1 << CTRL_RESET))
-	// 100 Mbps, Auto-Negotiation, Full-duplex
-	eth.WritePHYRegister(PHY_ADDR, DP_CTRL, (1<<CTRL_SPEED)|(1<<CTRL_ANEG)|(1<<CTRL_DUPLEX))
-	// 50MHz RMII Reference Clock Select, 2 bit tolerance Receive Elasticity Buffer Size
-	eth.WritePHYRegister(PHY_ADDR, DP_RCSR, (1<<RCSR_RMII_CS)|(1<<RCSR_RX_BUF))
+	phy = &dp83825i.PHY{
+		Address: PHY_ADDR,
+		MIIM:    eth,
+	}
 
-	return nil
+	return phy.Init()
 }

--- a/board/usbarmory/mk2/enet.go
+++ b/board/usbarmory/mk2/enet.go
@@ -169,10 +169,7 @@ var phy *dp83825i.PHY
 func EnablePHY(eth *enet.ENET) error {
 	configurePHYPads()
 
-	phy = &dp83825i.PHY{
-		Address: PHY_ADDR,
-		MIIM:    eth,
-	}
+	phy = &dp83825i.PHY{}
 
-	return phy.Init()
+	return phy.Init(PHY_ADDR, eth)
 }

--- a/board/usbarmory/mk2/led.go
+++ b/board/usbarmory/mk2/led.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/usbarmory/tamago/soc/nxp/enet"
 	"github.com/usbarmory/tamago/soc/nxp/gpio"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/iomuxc"
@@ -82,40 +81,16 @@ func init() {
 // LED turns on/off an LED by name.
 func LED(name string, on bool) (err error) {
 	var led *gpio.Pin
-	var eth *enet.ENET = imx6ul.ENET2
 
 	switch {
 	case strings.EqualFold(name, "white"):
 		led = white
 	case strings.EqualFold(name, "blue"):
 		led = blue
-	case strings.EqualFold(name, "green") && eth != nil:
-		val := uint16(1 << LEDCR1_LINK_LED_DRV)
-
-		if !on {
-			val |= 1 << LEDCR1_LINK_LED_OFF
-		}
-
-		eth.WritePHYRegister(PHY_ADDR, DP_LEDCR1, val)
-	case strings.EqualFold(name, "yellow") && eth != nil:
-		val := uint16(1 << LEDCR2_LED2_DRV_EN)
-
-		if !on {
-			val |= 1 << LEDCR2_LED2_DRV_VAL
-		}
-
-		// Clause 22 access to Clause 45 MMD registers (802.3-2008)
-
-		// set general MMD registers access
-		devad := uint16(0x1f)
-		// set address function
-		eth.WritePHYRegister(PHY_ADDR, DP_REGCR, uint16(MMD_FN_ADDR<<14)|devad)
-		// write address value
-		eth.WritePHYRegister(PHY_ADDR, DP_ADDAR, DP_LEDCR2)
-		// set data function
-		eth.WritePHYRegister(PHY_ADDR, DP_REGCR, uint16(MMD_FN_DATA<<14)|devad)
-		// write data value
-		eth.WritePHYRegister(PHY_ADDR, DP_ADDAR, val)
+	case strings.EqualFold(name, "green") && phy != nil:
+		return phy.LED(1, on)
+	case strings.EqualFold(name, "yellow") && phy != nil:
+		return phy.LED(2, on)
 	default:
 		return errors.New("invalid LED")
 	}

--- a/phy/microchip/ksz8081/phy.go
+++ b/phy/microchip/ksz8081/phy.go
@@ -69,14 +69,14 @@ func (hw *PHY) Negotiate() (err error) {
 	// HP Auto MDI/MDI-X mode, RMII 50MHz, LEDs: Activity/Link
 	ctrl := (1 << CTRL2_HP_MDIX) | (1 << CTRL2_RMII) | (1 << CTRL2_LED)
 
-	if hw.miim.WritePHYRegister(hw.pa, KSZ_PHYCTRL2, uint16(ctrl)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, KSZ_PHYCTRL2, uint16(ctrl)); err != nil {
 		return
 	}
 
 	// 100 Mbps, Full-duplex
 	ctrl = (1 << CTRL_SPEED) | (1 << CTRL_DUPLEX)
 
-	if hw.miim.WritePHYRegister(hw.pa, KSZ_CTRL, uint16(ctrl)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, KSZ_CTRL, uint16(ctrl)); err != nil {
 		return
 	}
 

--- a/phy/microchip/ksz8081/phy.go
+++ b/phy/microchip/ksz8081/phy.go
@@ -34,69 +34,72 @@ const (
 
 // PHY represents the KSZ8081 Ethernet PHY instance.
 type PHY struct {
-	// Address represents the PHY address and must be set before [Init]
-	Address int
-
-	// MIIM represents the MIIM interface and must be set before [Init]
-	MIIM phy.MIIM
-
+	miim  phy.MIIM
+	pa    int
 	speed int
 }
 
 // Init initializes the PHY and performs [PHY.Negotiate].
-func (phy *PHY) Init() (err error) {
-	if phy.MIIM == nil {
+func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
+	if miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
-	phy.speed = 0
+	hw.miim = miim
+	hw.pa = addr
+	hw.speed = 0
 
 	// software reset
-	if err = phy.MIIM.WritePHYRegister(phy.Address, KSZ_CTRL, (1 << CTRL_RESET)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, KSZ_CTRL, (1 << CTRL_RESET)); err != nil {
 		return
 	}
 
-	return phy.Negotiate()
+	return hw.Negotiate()
 }
 
 // Negotiate refreshes the PHY auto-negotiation status, currently only 100 Mbps
 // Auto-Negotiation (Full-duplex) is supported.
-func (phy *PHY) Negotiate() (err error) {
-	phy.speed = 0
+func (hw *PHY) Negotiate() (err error) {
+	hw.speed = 0
 
-	if phy.MIIM == nil {
+	if hw.miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
 	// HP Auto MDI/MDI-X mode, RMII 50MHz, LEDs: Activity/Link
 	ctrl := (1 << CTRL2_HP_MDIX) | (1 << CTRL2_RMII) | (1 << CTRL2_LED)
 
-	if phy.MIIM.WritePHYRegister(phy.Address, KSZ_PHYCTRL2, uint16(ctrl)); err != nil {
+	if hw.miim.WritePHYRegister(hw.pa, KSZ_PHYCTRL2, uint16(ctrl)); err != nil {
 		return
 	}
 
 	// 100 Mbps, Full-duplex
 	ctrl = (1 << CTRL_SPEED) | (1 << CTRL_DUPLEX)
 
-	if phy.MIIM.WritePHYRegister(phy.Address, KSZ_CTRL, uint16(ctrl)); err != nil {
+	if hw.miim.WritePHYRegister(hw.pa, KSZ_CTRL, uint16(ctrl)); err != nil {
 		return
 	}
 
-	phy.speed = 100
+	hw.speed = 100
 
 	return
 }
 
+// Address returns the PHY address passed at [PHY.Init].
+func (hw *PHY) Address() int {
+	return hw.pa
+}
+
 // Speed returns the PHY auto-negotiated speed.
-func (phy *PHY) Speed() int {
-	return phy.speed
+func (hw *PHY) Speed() int {
+	return hw.speed
 }
 
 // EnableInterrupts enables all available transceiver interrupts.
-func (phy *PHY) EnableInterrupts() (err error) {
-	if phy.MIIM == nil {
+func (hw *PHY) EnableInterrupts() (err error) {
+	if hw.miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
-	return phy.MIIM.WritePHYRegister(phy.Address, KSZ_INT, 0xff00)
+	return hw.miim.WritePHYRegister(hw.pa, KSZ_INT, 0xff00)
 }

--- a/phy/microchip/ksz8081/phy.go
+++ b/phy/microchip/ksz8081/phy.go
@@ -1,0 +1,102 @@
+// KSZ8081RNB Ethernet PHY support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package ksz8081 implements a driver for the Microchip KSZ8081RNB Ethernet
+// Transceiver adopting the following specifications:
+//   - DS000002202C (01-09-18)
+package ksz8081
+
+import (
+	"errors"
+
+	"github.com/usbarmory/tamago/phy"
+)
+
+// PHY registers
+const (
+	KSZ_CTRL    = 0x00
+	CTRL_RESET  = 15
+	CTRL_SPEED  = 13
+	CTRL_DUPLEX = 8
+
+	KSZ_INT = 0x1b
+
+	KSZ_PHYCTRL2  = 0x1f
+	CTRL2_HP_MDIX = 15
+	CTRL2_RMII    = 7
+	CTRL2_LED     = 4
+)
+
+// PHY represents the KSZ8081 Ethernet PHY instance.
+type PHY struct {
+	// Address represents the PHY address and must be set before [Init]
+	Address int
+
+	// MIIM represents the MIIM interface and must be set before [Init]
+	MIIM phy.MIIM
+
+	speed int
+}
+
+// Init initializes the PHY and performs [PHY.Negotiate].
+func (phy *PHY) Init() (err error) {
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	phy.speed = 0
+
+	// software reset
+	if err = phy.MIIM.WritePHYRegister(phy.Address, KSZ_CTRL, (1 << CTRL_RESET)); err != nil {
+		return
+	}
+
+	return phy.Negotiate()
+}
+
+// Negotiate refreshes the PHY auto-negotiation status, currently only 100 Mbps
+// Auto-Negotiation (Full-duplex) is supported.
+func (phy *PHY) Negotiate() (err error) {
+	phy.speed = 0
+
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	// HP Auto MDI/MDI-X mode, RMII 50MHz, LEDs: Activity/Link
+	ctrl := (1 << CTRL2_HP_MDIX) | (1 << CTRL2_RMII) | (1 << CTRL2_LED)
+
+	if phy.MIIM.WritePHYRegister(phy.Address, KSZ_PHYCTRL2, uint16(ctrl)); err != nil {
+		return
+	}
+
+	// 100 Mbps, Full-duplex
+	ctrl = (1 << CTRL_SPEED) | (1 << CTRL_DUPLEX)
+
+	if phy.MIIM.WritePHYRegister(phy.Address, KSZ_CTRL, uint16(ctrl)); err != nil {
+		return
+	}
+
+	phy.speed = 100
+
+	return
+}
+
+// Speed returns the PHY auto-negotiated speed.
+func (phy *PHY) Speed() int {
+	return phy.speed
+}
+
+// EnableInterrupts enables all available transceiver interrupts.
+func (phy *PHY) EnableInterrupts() (err error) {
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	return phy.MIIM.WritePHYRegister(phy.Address, KSZ_INT, 0xff00)
+}

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -56,20 +56,16 @@ var PollInterval = 10 * time.Millisecond
 
 // PHY represents the LAN8840 Ethernet PHY instance.
 type PHY struct {
-	// Address represents the PHY address and must be set before [Init]
-	Address int
-
-	// MIIM represents the MIIM interface and must be set before [Init]
-	MIIM    phy.MIIM
-
+	miim  phy.MIIM
+	pa    int
 	speed int
 }
 
-func (phy *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
+func (hw *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
 	deadline := time.Now().Add(WaitTimeout)
 
 	for {
-		if data, err = phy.MIIM.ReadPHYRegister(phy.Address, addr); err != nil {
+		if data, err = hw.miim.ReadPHYRegister(hw.pa, addr); err != nil {
 			return
 		}
 
@@ -86,19 +82,21 @@ func (phy *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err erro
 }
 
 // Init initializes the PHY and performs [PHY.Negotiate].
-func (phy *PHY) Init() (err error) {
-	if phy.MIIM == nil {
+func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
+	if miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
-	phy.speed = 0
+	hw.miim = miim
+	hw.pa = addr
+	hw.speed = 0
 
 	// software reset
-	if err = phy.MIIM.WritePHYRegister(phy.Address, PHY_CTRL, (1 << CTRL_RESET)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, PHY_CTRL, (1 << CTRL_RESET)); err != nil {
 		return
 	}
 
-	control, err := phy.wait(PHY_CTRL, 1<<CTRL_RESET, 0)
+	control, err := hw.wait(PHY_CTRL, 1<<CTRL_RESET, 0)
 
 	if err != nil {
 		return fmt.Errorf("could not reset PHY, %v", err)
@@ -107,40 +105,40 @@ func (phy *PHY) Init() (err error) {
 	// enable and restart auto-negotiation
 	control |= (1 << CTRL_ANEG) | (1 << CTRL_ANEG_RESTART)
 
-	if err = phy.MIIM.WritePHYRegister(phy.Address, PHY_CTRL, control); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, PHY_CTRL, control); err != nil {
 		return
 	}
 
 	statusMask := uint16((1 << STATUS_LINK) | (1 << STATUS_ANEG_COMPLETE))
 
-	if _, err = phy.wait(PHY_STATUS, statusMask, statusMask); err != nil {
+	if _, err = hw.wait(PHY_STATUS, statusMask, statusMask); err != nil {
 		return fmt.Errorf("auto-negotiation status error, %w", err)
 	}
 
-	return phy.Negotiate()
+	return hw.Negotiate()
 }
 
 // Negotiate refreshes the PHY auto-negotiation status, currently only 100/1000
 // Mbps Auto-Negotiation (Full-duplex) is supported.
-func (phy *PHY) Negotiate() (err error) {
+func (hw *PHY) Negotiate() (err error) {
 	var local, partner uint16
 
-	phy.speed = 0
+	hw.speed = 0
 
-	if phy.MIIM == nil {
+	if hw.miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
-	if local, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_1000_CTRL); err != nil {
+	if local, err = hw.miim.ReadPHYRegister(hw.pa, PHY_1000_CTRL); err != nil {
 		return fmt.Errorf("could not read 1000BASE-T control register, %v", err)
 	}
 
-	if partner, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_1000_STATUS); err != nil {
+	if partner, err = hw.miim.ReadPHYRegister(hw.pa, PHY_1000_STATUS); err != nil {
 		return fmt.Errorf("could not read 1000BASE-T status register, %v", err)
 	}
 
 	if local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0 {
-		phy.speed = 1000
+		hw.speed = 1000
 		return
 	}
 
@@ -148,11 +146,11 @@ func (phy *PHY) Negotiate() (err error) {
 		return fmt.Errorf("unsupported half-duplex management link")
 	}
 
-	if local, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_ANEG_ADV); err != nil {
+	if local, err = hw.miim.ReadPHYRegister(hw.pa, PHY_ANEG_ADV); err != nil {
 		return fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
 	}
 
-	if partner, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_ANEG_LPA); err != nil {
+	if partner, err = hw.miim.ReadPHYRegister(hw.pa, PHY_ANEG_LPA); err != nil {
 		return fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
 	}
 
@@ -160,7 +158,7 @@ func (phy *PHY) Negotiate() (err error) {
 
 	switch {
 	case common&ANEG_ADV_100_FULL != 0:
-		phy.speed = 100
+		hw.speed = 100
 	case common&ANEG_ADV_100_HALF != 0:
 		return fmt.Errorf("unsupported half-duplex management link")
 	case common&(ANEG_ADV_10_FULL|ANEG_ADV_10_HALF) != 0:
@@ -172,7 +170,12 @@ func (phy *PHY) Negotiate() (err error) {
 	return
 }
 
+// Address returns the PHY address passed at [PHY.Init].
+func (hw *PHY) Address() int {
+	return hw.pa
+}
+
 // Speed returns the PHY auto-negotiated speed.
-func (phy *PHY) Speed() int {
-	return phy.speed
+func (hw *PHY) Speed() int {
+	return hw.speed
 }

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -1,0 +1,178 @@
+// LAN8840 Ethernet PHY support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package lan8840 implements a driver for the Microchip LAN8840 Gigabit
+// Ethernet Transceiver adopting the following specifications:
+//   - DS00004727A (09-30-22)
+package lan8840
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/usbarmory/tamago/phy"
+)
+
+// PHY registers
+const (
+	PHY_CTRL        = 0x00
+	PHY_STATUS      = 0x01
+	PHY_ANEG_ADV    = 0x04
+	PHY_ANEG_LPA    = 0x05
+	PHY_1000_CTRL   = 0x09
+	PHY_1000_STATUS = 0x0a
+
+	CTRL_RESET        = 15
+	CTRL_SPEED0       = 13
+	CTRL_ANEG         = 12
+	CTRL_ANEG_RESTART = 9
+	CTRL_DUPLEX       = 8
+	CTRL_SPEED1       = 6
+
+	STATUS_LINK          = 2
+	STATUS_ANEG_COMPLETE = 5
+
+	ANEG_ADV_10_HALF   = 1 << 5
+	ANEG_ADV_10_FULL   = 1 << 6
+	ANEG_ADV_100_HALF  = 1 << 7
+	ANEG_ADV_100_FULL  = 1 << 8
+	ANEG_ADV_1000_HALF = 1 << 8
+	ANEG_ADV_1000_FULL = 1 << 9
+	ANEG_LPA_1000_HALF = 1 << 10
+	ANEG_LPA_1000_FULL = 1 << 11
+)
+
+// WaitTimeout represents the timeout for PHY register writes
+var WaitTimeout = 10 * time.Second
+
+// PollInterval represents the delay between PHY register write attempts
+var PollInterval = 10 * time.Millisecond
+
+// PHY represents the LAN8840 Ethernet PHY instance.
+type PHY struct {
+	// Address represents the PHY address and must be set before [Init]
+	Address int
+
+	// MIIM represents the MIIM interface and must be set before [Init]
+	MIIM    phy.MIIM
+
+	speed int
+}
+
+func (phy *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
+	deadline := time.Now().Add(WaitTimeout)
+
+	for {
+		if data, err = phy.MIIM.ReadPHYRegister(phy.Address, addr); err != nil {
+			return
+		}
+
+		if data&mask == value {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			return 0, fmt.Errorf("timed out waiting for PHY register %#x", addr)
+		}
+
+		time.Sleep(PollInterval)
+	}
+}
+
+// Init initializes the PHY and performs [PHY.Negotiate].
+func (phy *PHY) Init() (err error) {
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	phy.speed = 0
+
+	// software reset
+	if err = phy.MIIM.WritePHYRegister(phy.Address, PHY_CTRL, (1 << CTRL_RESET)); err != nil {
+		return
+	}
+
+	control, err := phy.wait(PHY_CTRL, 1<<CTRL_RESET, 0)
+
+	if err != nil {
+		return fmt.Errorf("could not reset PHY, %v", err)
+	}
+
+	// enable and restart auto-negotiation
+	control |= (1 << CTRL_ANEG) | (1 << CTRL_ANEG_RESTART)
+
+	if err = phy.MIIM.WritePHYRegister(phy.Address, PHY_CTRL, control); err != nil {
+		return
+	}
+
+	statusMask := uint16((1 << STATUS_LINK) | (1 << STATUS_ANEG_COMPLETE))
+
+	if _, err = phy.wait(PHY_STATUS, statusMask, statusMask); err != nil {
+		return fmt.Errorf("auto-negotiation status error, %w", err)
+	}
+
+	return phy.Negotiate()
+}
+
+// Negotiate refreshes the PHY auto-negotiation status, currently only 100/1000
+// Mbps Auto-Negotiation (Full-duplex) is supported.
+func (phy *PHY) Negotiate() (err error) {
+	var local, partner uint16
+
+	phy.speed = 0
+
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	if local, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_1000_CTRL); err != nil {
+		return fmt.Errorf("could not read 1000BASE-T control register, %v", err)
+	}
+
+	if partner, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_1000_STATUS); err != nil {
+		return fmt.Errorf("could not read 1000BASE-T status register, %v", err)
+	}
+
+	if local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0 {
+		phy.speed = 1000
+		return
+	}
+
+	if local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0 {
+		return fmt.Errorf("unsupported half-duplex management link")
+	}
+
+	if local, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_ANEG_ADV); err != nil {
+		return fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
+	}
+
+	if partner, err = phy.MIIM.ReadPHYRegister(phy.Address, PHY_ANEG_LPA); err != nil {
+		return fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
+	}
+
+	common := local & partner
+
+	switch {
+	case common&ANEG_ADV_100_FULL != 0:
+		phy.speed = 100
+	case common&ANEG_ADV_100_HALF != 0:
+		return fmt.Errorf("unsupported half-duplex management link")
+	case common&(ANEG_ADV_10_FULL|ANEG_ADV_10_HALF) != 0:
+		return fmt.Errorf("unsupported 10 Mbps management link")
+	default:
+		return fmt.Errorf("management PHY has no common advertised mode")
+	}
+
+	return
+}
+
+// Speed returns the PHY auto-negotiated speed.
+func (phy *PHY) Speed() int {
+	return phy.speed
+}

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -1,0 +1,25 @@
+// Ethernet PHY support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package phy provides abstraction for Ethernet PHY driver support.
+package phy
+
+// MIIM is the common interface used by sub-packages to access Media
+// Independent Interface Management (MIIM) buses.
+type MIIM interface {
+	// Init represents the MIIM bus initializattion function.
+	Init() error
+
+	// ReadPHYRegister reads a standard management register of a connected Ethernet
+	// PHY (IEE 802.3-2008 Clause 22).
+	ReadPHYRegister(pa int, ra int) (data uint16, err error)
+
+	// WritePHYRegister writes a standard management register of a connected
+	// Ethernet PHY (IEE 802.3-2008 Clause 22).
+	WritePHYRegister(pa int, ra int, data uint16) (err error)
+}

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -23,3 +23,19 @@ type MIIM interface {
 	// Ethernet PHY (IEE 802.3-2008 Clause 22).
 	WritePHYRegister(pa int, ra int, data uint16) (err error)
 }
+
+// PHY is the common interface used by sub-packages to implement Ethernet PHY
+// drivers.
+type PHY interface {
+	// Init represents the PHY initialization function.
+	Init(addr int, miim MIIM) error
+
+	// Negotiate represents the PHY auto-negotiation function.
+	Negotiate() error
+
+	// Address reports the PHY address.
+	Address() int
+
+	// Speed reports the PHY auto-negotiated speed.
+	Speed() int
+}

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -11,6 +11,8 @@ package phy
 
 // MIIM is the common interface used by sub-packages to access Media
 // Independent Interface Management (MIIM) buses.
+//
+// The bus is expected to be already initialized when passed to a PHY driver.
 type MIIM interface {
 	// ReadPHYRegister reads a standard management register of a connected Ethernet
 	// PHY (IEEE 802.3-2008 Clause 22).

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -12,15 +12,15 @@ package phy
 // MIIM is the common interface used by sub-packages to access Media
 // Independent Interface Management (MIIM) buses.
 type MIIM interface {
-	// Init represents the MIIM bus initializattion function.
+	// Init represents the MIIM bus initialization function.
 	Init() error
 
 	// ReadPHYRegister reads a standard management register of a connected Ethernet
-	// PHY (IEE 802.3-2008 Clause 22).
+	// PHY (IEEE 802.3-2008 Clause 22).
 	ReadPHYRegister(pa int, ra int) (data uint16, err error)
 
 	// WritePHYRegister writes a standard management register of a connected
-	// Ethernet PHY (IEE 802.3-2008 Clause 22).
+	// Ethernet PHY (IEEE 802.3-2008 Clause 22).
 	WritePHYRegister(pa int, ra int, data uint16) (err error)
 }
 

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -12,9 +12,6 @@ package phy
 // MIIM is the common interface used by sub-packages to access Media
 // Independent Interface Management (MIIM) buses.
 type MIIM interface {
-	// Init represents the MIIM bus initialization function.
-	Init() error
-
 	// ReadPHYRegister reads a standard management register of a connected Ethernet
 	// PHY (IEEE 802.3-2008 Clause 22).
 	ReadPHYRegister(pa int, ra int) (data uint16, err error)

--- a/phy/ti/dp83825i/led.go
+++ b/phy/ti/dp83825i/led.go
@@ -1,0 +1,73 @@
+// DP83825I Ethernet PHY support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package dp83825i
+
+import "errors"
+
+// PHY LED control registers
+const (
+	DP_LEDCR1           = 0x18
+	LEDCR1_LINK_LED_DRV = 4
+	LEDCR1_LINK_LED_OFF = 1
+
+	DP_LEDCR2           = 0x469
+	LEDCR2_LED2_DRV_VAL = 5
+	LEDCR2_LED2_DRV_EN  = 4
+)
+
+// Table 22–9, MMD access control register bit definitions, 802.3-2008
+const (
+	MMD_FN_ADDR = 0b00
+	MMD_FN_DATA = 0b01
+)
+
+// LED controls the PHY connected LED state.
+func (phy *PHY) LED(n int, on bool) (err error) {
+	switch n {
+	case 0,1:
+		val := uint16(1 << LEDCR1_LINK_LED_DRV)
+
+		if !on {
+			val |= 1 << LEDCR1_LINK_LED_OFF
+		}
+
+		return phy.MIIM.WritePHYRegister(phy.Address, DP_LEDCR1, val)
+	case 2:
+		val := uint16(1 << LEDCR2_LED2_DRV_EN)
+
+		if !on {
+			val |= 1 << LEDCR2_LED2_DRV_VAL
+		}
+
+		// Clause 22 access to Clause 45 MMD registers (802.3-2008)
+
+		// set general MMD registers access
+		devad := uint16(0x1f)
+
+		// set address function
+		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_REGCR, uint16(MMD_FN_ADDR<<14)|devad); err != nil {
+			return
+		}
+
+		// write address value
+		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_ADDAR, DP_LEDCR2); err != nil {
+			return
+		}
+
+		// set data function
+		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_REGCR, uint16(MMD_FN_DATA<<14)|devad); err != nil {
+			return
+		}
+
+		// write data value
+		return phy.MIIM.WritePHYRegister(phy.Address, DP_ADDAR, val)
+	}
+
+	return errors.New("invalid LED")
+}

--- a/phy/ti/dp83825i/led.go
+++ b/phy/ti/dp83825i/led.go
@@ -30,7 +30,7 @@ const (
 // LED controls the PHY connected LED state.
 func (hw *PHY) LED(n int, on bool) (err error) {
 	switch n {
-	case 0,1:
+	case 0, 1:
 		val := uint16(1 << LEDCR1_LINK_LED_DRV)
 
 		if !on {

--- a/phy/ti/dp83825i/led.go
+++ b/phy/ti/dp83825i/led.go
@@ -28,7 +28,7 @@ const (
 )
 
 // LED controls the PHY connected LED state.
-func (phy *PHY) LED(n int, on bool) (err error) {
+func (hw *PHY) LED(n int, on bool) (err error) {
 	switch n {
 	case 0,1:
 		val := uint16(1 << LEDCR1_LINK_LED_DRV)
@@ -37,7 +37,7 @@ func (phy *PHY) LED(n int, on bool) (err error) {
 			val |= 1 << LEDCR1_LINK_LED_OFF
 		}
 
-		return phy.MIIM.WritePHYRegister(phy.Address, DP_LEDCR1, val)
+		return hw.miim.WritePHYRegister(hw.pa, DP_LEDCR1, val)
 	case 2:
 		val := uint16(1 << LEDCR2_LED2_DRV_EN)
 
@@ -51,22 +51,22 @@ func (phy *PHY) LED(n int, on bool) (err error) {
 		devad := uint16(0x1f)
 
 		// set address function
-		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_REGCR, uint16(MMD_FN_ADDR<<14)|devad); err != nil {
+		if err = hw.miim.WritePHYRegister(hw.pa, DP_REGCR, uint16(MMD_FN_ADDR<<14)|devad); err != nil {
 			return
 		}
 
 		// write address value
-		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_ADDAR, DP_LEDCR2); err != nil {
+		if err = hw.miim.WritePHYRegister(hw.pa, DP_ADDAR, DP_LEDCR2); err != nil {
 			return
 		}
 
 		// set data function
-		if err = phy.MIIM.WritePHYRegister(phy.Address, DP_REGCR, uint16(MMD_FN_DATA<<14)|devad); err != nil {
+		if err = hw.miim.WritePHYRegister(hw.pa, DP_REGCR, uint16(MMD_FN_DATA<<14)|devad); err != nil {
 			return
 		}
 
 		// write data value
-		return phy.MIIM.WritePHYRegister(phy.Address, DP_ADDAR, val)
+		return hw.miim.WritePHYRegister(hw.pa, DP_ADDAR, val)
 	}
 
 	return errors.New("invalid LED")

--- a/phy/ti/dp83825i/phy.go
+++ b/phy/ti/dp83825i/phy.go
@@ -69,14 +69,14 @@ func (hw *PHY) Negotiate() (err error) {
 	}
 
 	// 100 Mbps, Auto-Negotiation, Full-duplex
-	ctrl := (1<<CTRL_SPEED)|(1<<CTRL_ANEG)|(1<<CTRL_DUPLEX)
+	ctrl := (1 << CTRL_SPEED) | (1 << CTRL_ANEG) | (1 << CTRL_DUPLEX)
 
 	if err = hw.miim.WritePHYRegister(hw.pa, DP_CTRL, uint16(ctrl)); err != nil {
 		return fmt.Errorf("could not configure auto-negotiation, %v", err)
 	}
 
 	// 50MHz RMII Reference Clock Select, 2 bit tolerance Receive Elasticity Buffer Size
-	rcsr := (1<<RCSR_RMII_CS)|(1<<RCSR_RX_BUF)
+	rcsr := (1 << RCSR_RMII_CS) | (1 << RCSR_RX_BUF)
 
 	if err = hw.miim.WritePHYRegister(hw.pa, DP_RCSR, uint16(rcsr)); err != nil {
 		return fmt.Errorf("could not select reference clock, %v", err)

--- a/phy/ti/dp83825i/phy.go
+++ b/phy/ti/dp83825i/phy.go
@@ -1,0 +1,95 @@
+// DP83825I Ethernet PHY support
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package dp83825i implements a driver for the Texas Instruments DP83825I
+// Ethernet Transceiver adopting the following specifications:
+//   - SNLS638C – DECEMBER 2018 – REVISED APRIL 2026
+package dp83825i
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/usbarmory/tamago/phy"
+)
+
+// PHY registers
+const (
+	DP_CTRL     = 0x00
+	CTRL_RESET  = 15
+	CTRL_SPEED  = 13
+	CTRL_ANEG   = 12
+	CTRL_DUPLEX = 8
+
+	DP_REGCR = 0xd
+	DP_ADDAR = 0xe
+
+	DP_RCSR      = 0x17
+	RCSR_RMII_CS = 7
+	RCSR_RX_BUF  = 0
+)
+
+// PHY represents the DP83825I Ethernet PHY instance.
+type PHY struct {
+	// Address represents the PHY address and must be set before [Init]
+	Address int
+
+	// MIIM represents the MIIM interface and must be set before [Init]
+	MIIM    phy.MIIM
+
+	speed int
+}
+
+// Init initializes the PHY and performs [PHY.Negotiate].
+func (phy *PHY) Init() (err error) {
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	phy.speed = 0
+
+	// software reset
+	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_CTRL, (1 << CTRL_RESET)); err != nil {
+		return
+	}
+
+	return phy.Negotiate()
+}
+
+// Negotiate refreshes the PHY auto-negotiation status, currently only 100 Mbps
+// Auto-Negotiation (Full-duplex) is supported.
+func (phy *PHY) Negotiate() (err error) {
+	phy.speed = 0
+
+	if phy.MIIM == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	// 100 Mbps, Auto-Negotiation, Full-duplex
+	ctrl := (1<<CTRL_SPEED)|(1<<CTRL_ANEG)|(1<<CTRL_DUPLEX)
+
+	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_CTRL, uint16(ctrl)); err != nil {
+		return fmt.Errorf("could not configure auto-negotiation, %v", err)
+	}
+
+	// 50MHz RMII Reference Clock Select, 2 bit tolerance Receive Elasticity Buffer Size
+	rcsr := (1<<RCSR_RMII_CS)|(1<<RCSR_RX_BUF)
+
+	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_RCSR, uint16(rcsr)); err != nil {
+		return fmt.Errorf("could not select reference clock, %v", err)
+	}
+
+	phy.speed = 100
+
+	return
+}
+
+// Speed returns the PHY auto-negotiated speed.
+func (phy *PHY) Speed() int {
+	return phy.speed
+}

--- a/phy/ti/dp83825i/phy.go
+++ b/phy/ti/dp83825i/phy.go
@@ -36,60 +36,63 @@ const (
 
 // PHY represents the DP83825I Ethernet PHY instance.
 type PHY struct {
-	// Address represents the PHY address and must be set before [Init]
-	Address int
-
-	// MIIM represents the MIIM interface and must be set before [Init]
-	MIIM    phy.MIIM
-
+	miim  phy.MIIM
+	pa    int
 	speed int
 }
 
 // Init initializes the PHY and performs [PHY.Negotiate].
-func (phy *PHY) Init() (err error) {
-	if phy.MIIM == nil {
+func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
+	if miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
-	phy.speed = 0
+	hw.miim = miim
+	hw.pa = addr
+	hw.speed = 0
 
 	// software reset
-	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_CTRL, (1 << CTRL_RESET)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, DP_CTRL, (1 << CTRL_RESET)); err != nil {
 		return
 	}
 
-	return phy.Negotiate()
+	return hw.Negotiate()
 }
 
 // Negotiate refreshes the PHY auto-negotiation status, currently only 100 Mbps
 // Auto-Negotiation (Full-duplex) is supported.
-func (phy *PHY) Negotiate() (err error) {
-	phy.speed = 0
+func (hw *PHY) Negotiate() (err error) {
+	hw.speed = 0
 
-	if phy.MIIM == nil {
+	if hw.miim == nil {
 		return errors.New("invalid PHY instance")
 	}
 
 	// 100 Mbps, Auto-Negotiation, Full-duplex
 	ctrl := (1<<CTRL_SPEED)|(1<<CTRL_ANEG)|(1<<CTRL_DUPLEX)
 
-	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_CTRL, uint16(ctrl)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, DP_CTRL, uint16(ctrl)); err != nil {
 		return fmt.Errorf("could not configure auto-negotiation, %v", err)
 	}
 
 	// 50MHz RMII Reference Clock Select, 2 bit tolerance Receive Elasticity Buffer Size
 	rcsr := (1<<RCSR_RMII_CS)|(1<<RCSR_RX_BUF)
 
-	if err = phy.MIIM.WritePHYRegister(phy.Address, DP_RCSR, uint16(rcsr)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, DP_RCSR, uint16(rcsr)); err != nil {
 		return fmt.Errorf("could not select reference clock, %v", err)
 	}
 
-	phy.speed = 100
+	hw.speed = 100
 
 	return
 }
 
+// Address returns the PHY address passed at [PHY.Init].
+func (hw *PHY) Address() int {
+	return hw.pa
+}
+
 // Speed returns the PHY auto-negotiated speed.
-func (phy *PHY) Speed() int {
-	return phy.speed
+func (hw *PHY) Speed() int {
+	return hw.speed
 }

--- a/soc/microchip/miim/miim.go
+++ b/soc/microchip/miim/miim.go
@@ -67,17 +67,19 @@ type MIIM struct {
 }
 
 // Init initializes and enables an MIIM controller instance.
-func (hw *MIIM) Init() {
+func (hw *MIIM) Init() (err error) {
 	hw.Lock()
 	defer hw.Unlock()
 
 	if hw.Base == 0 {
-		panic("invalid MIIM controller instance")
+		return errors.New("invalid MIIM controller instance")
 	}
 
 	if hw.Timeout == 0 {
 		hw.Timeout = Timeout
 	}
+
+	return nil
 }
 
 func (hw *MIIM) mdio(phyad, regad, wrdata, op uint32, read bool) (rddata uint16, err error) {

--- a/soc/nxp/enet/enet.go
+++ b/soc/nxp/enet/enet.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/usbarmory/tamago/internal/reg"
 )
@@ -139,6 +140,9 @@ type ENET struct {
 	// Statistics about the MAC
 	Stats Stats
 
+	// Timeout for MIIM operations
+	Timeout time.Duration
+
 	// control registers
 	eir  uint32
 	eimr uint32
@@ -186,6 +190,10 @@ func (hw *ENET) Init() (err error) {
 
 	if hw.RingSize == 0 {
 		hw.RingSize = defaultRingSize
+	}
+
+	if hw.Timeout == 0 {
+		hw.Timeout = Timeout
 	}
 
 	hw.eir = hw.Base + ENETx_EIR

--- a/soc/nxp/enet/enet.go
+++ b/soc/nxp/enet/enet.go
@@ -214,12 +214,10 @@ func (hw *ENET) Init() (err error) {
 	hw.ftrl = hw.Base + ENETx_FTRL
 	hw.racc = hw.Base + ENETx_RACC
 
-	hw.setup()
-
-	return
+	return hw.setup()
 }
 
-func (hw *ENET) setup() {
+func (hw *ENET) setup() (err error) {
 	// enable clock
 	reg.SetN(hw.CCGR, hw.CG, 0b11, 0b11)
 
@@ -275,8 +273,10 @@ func (hw *ENET) setup() {
 
 	if hw.EnablePHY != nil {
 		// enable Ethernet PHY
-		hw.EnablePHY(hw)
+		err = hw.EnablePHY(hw)
 	}
+
+	return
 }
 
 // SetMAC allows to change the controller physical address register after

--- a/soc/nxp/enet/mii.go
+++ b/soc/nxp/enet/mii.go
@@ -41,12 +41,14 @@ func (hw *ENET) MDIO45(op, prtad, devad int, data uint16) (frame uint32) {
 
 // ReadPHYRegister reads a standard management register of a connected Ethernet
 // PHY (IEE 802.3-2008 Clause 22).
-func (hw *ENET) ReadPHYRegister(pa int, ra int) (data uint16) {
-	return uint16(hw.MDIO22(mdio.OP_READ, pa, ra, 0))
+func (hw *ENET) ReadPHYRegister(pa int, ra int) (data uint16, err error) {
+	data = uint16(hw.MDIO22(mdio.OP_READ, pa, ra, 0))
+	return
 }
 
 // WritePHYRegister writes a standard management register of a connected
 // Ethernet PHY (IEE 802.3-2008 Clause 22).
-func (hw *ENET) WritePHYRegister(pa int, ra int, data uint16) {
+func (hw *ENET) WritePHYRegister(pa int, ra int, data uint16) (err error) {
 	hw.MDIO22(mdio.OP_WRITE, pa, ra, data)
+	return
 }

--- a/soc/nxp/enet/mii.go
+++ b/soc/nxp/enet/mii.go
@@ -9,46 +9,58 @@
 package enet
 
 import (
+	"errors"
+	"time"
+
 	"github.com/usbarmory/tamago/internal/mdio"
 	"github.com/usbarmory/tamago/internal/reg"
 )
 
+// Timeout is the default timeout for MIIM operations.
+const Timeout = 1 * time.Second
+
 // MDIO22 transmits an MII frame (IEEE 802.3-2008 Clause 22) to a connected
 // Ethernet PHY, the transacted frame is returned.
-func (hw *ENET) MDIO22(op, pa, ra int, data uint16) (frame uint32) {
+func (hw *ENET) MDIO22(op, pa, ra int, data uint16) (frame uint32, err error) {
 	reg.Set(hw.eir, IRQ_MII)
 	defer reg.Set(hw.eir, IRQ_MII)
 
 	frame = mdio.Frame(mdio.ST, uint32(op), uint32(pa), uint32(ra), mdio.TA, data)
 	reg.Write(hw.mmfr, frame)
 
-	reg.Wait(hw.eir, IRQ_MII, 1, 1)
-	return reg.Read(hw.mmfr)
+	if !reg.WaitFor(hw.Timeout, hw.eir, IRQ_MII, 1, 1) {
+		return 0, errors.New("command timeout")
+	}
+
+	return reg.Read(hw.mmfr), nil
 }
 
 // MDIO45 transmits an MII frame (IEEE 802.3-2008 Clause 45) to a connected
 // Ethernet PHY, the transacted frame is returned.
-func (hw *ENET) MDIO45(op, prtad, devad int, data uint16) (frame uint32) {
+func (hw *ENET) MDIO45(op, prtad, devad int, data uint16) (frame uint32, err error) {
 	reg.Set(hw.eir, IRQ_MII)
 	defer reg.Set(hw.eir, IRQ_MII)
 
 	frame = mdio.Frame(mdio.ST_45, uint32(op), uint32(prtad), uint32(devad), mdio.TA_45, data)
 	reg.Write(hw.mmfr, frame)
 
-	reg.Wait(hw.eir, IRQ_MII, 1, 1)
-	return reg.Read(hw.mmfr)
+	if !reg.WaitFor(hw.Timeout, hw.eir, IRQ_MII, 1, 1) {
+		return 0, errors.New("command timeout")
+	}
+
+	return reg.Read(hw.mmfr), nil
 }
 
 // ReadPHYRegister reads a standard management register of a connected Ethernet
 // PHY (IEEE 802.3-2008 Clause 22).
 func (hw *ENET) ReadPHYRegister(pa int, ra int) (data uint16, err error) {
-	data = uint16(hw.MDIO22(mdio.OP_READ, pa, ra, 0))
-	return
+	frame, err := hw.MDIO22(mdio.OP_READ, pa, ra, 0)
+	return uint16(frame), err
 }
 
 // WritePHYRegister writes a standard management register of a connected
 // Ethernet PHY (IEEE 802.3-2008 Clause 22).
 func (hw *ENET) WritePHYRegister(pa int, ra int, data uint16) (err error) {
-	hw.MDIO22(mdio.OP_WRITE, pa, ra, data)
+	_, err = hw.MDIO22(mdio.OP_WRITE, pa, ra, data)
 	return
 }

--- a/soc/nxp/enet/mii.go
+++ b/soc/nxp/enet/mii.go
@@ -40,14 +40,14 @@ func (hw *ENET) MDIO45(op, prtad, devad int, data uint16) (frame uint32) {
 }
 
 // ReadPHYRegister reads a standard management register of a connected Ethernet
-// PHY (IEE 802.3-2008 Clause 22).
+// PHY (IEEE 802.3-2008 Clause 22).
 func (hw *ENET) ReadPHYRegister(pa int, ra int) (data uint16, err error) {
 	data = uint16(hw.MDIO22(mdio.OP_READ, pa, ra, 0))
 	return
 }
 
 // WritePHYRegister writes a standard management register of a connected
-// Ethernet PHY (IEE 802.3-2008 Clause 22).
+// Ethernet PHY (IEEE 802.3-2008 Clause 22).
 func (hw *ENET) WritePHYRegister(pa int, ra int, data uint16) (err error) {
 	hw.MDIO22(mdio.OP_WRITE, pa, ra, data)
 	return


### PR DESCRIPTION
This PR moves all PHY configuration and control code to its own sub-packages under `phy`.