### PR TITLE
devcpu: preserve first frame after initialization

### DIFF
--- a/soc/microchip/devcpu/port.go
+++ b/soc/microchip/devcpu/port.go
@@ -163,10 +163,14 @@ func (p *Port) SetMAC(mac net.HardwareAddr) {
 }
 
 func (p *Port) abortInjection() (complete bool) {
-	reg.Set(p.inj_ctrl, CTRL_ABORT)
-	deadline := time.Now().Add(InjectionTimeout)
+	var deadline time.Time
 
 	for reg.Get(p.inj_status, INJ_STATUS_INJ_IN_PROGRESS+p.Group) {
+		if deadline.IsZero() {
+			reg.Set(p.inj_ctrl, CTRL_ABORT)
+			deadline = time.Now().Add(InjectionTimeout)
+		}
+
 		if !time.Now().Before(deadline) {
 			p.Stats.TxAbortTimeouts++
 			return


### PR DESCRIPTION
Port.Init unconditionally asserted INJ_CTRL.ABORT while initializing the manual injector, even when INJ_STATUS reported no frame in progress. On LAN969x, that idle abort caused the first subsequently injected frame to be discarded; later frames transmitted normally.

Check INJ_IN_PROGRESS before asserting ABORT. Error recovery still aborts partial frames, while a clean initialization no longer consumes the first management or front-panel packet.