### PR TITLE
phy: align LAN8840 and LAN8804 APIs

### DIFF
--- a/bits/bits16.go
+++ b/bits/bits16.go
@@ -1,0 +1,47 @@
+// https://github.com/usbarmory/tamago
+//
+// Copyright (c) The TamaGo Authors. All Rights Reserved.
+//
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package bits
+
+// Get16 returns whether a specific bit position is set at the pointed value.
+func Get16(addr *uint16, pos int) bool {
+	return (int(*addr)>>pos)&1 == 1
+}
+
+// Set16 modifies the pointed value by setting an individual bit at the
+// position argument.
+func Set16(addr *uint16, pos int) {
+	*addr |= (1 << pos)
+}
+
+// SetTo16 modifies the pointed value by setting an individual bit at the
+// position argument.
+func SetTo16(addr *uint16, pos int, val bool) {
+	if val {
+		Set16(addr, pos)
+	} else {
+		Clear16(addr, pos)
+	}
+}
+
+// Clear16 modifies the pointed value by clearing an individual bit at the
+// position argument.
+func Clear16(addr *uint16, pos int) {
+	*addr &= ^(1 << pos)
+}
+
+// GetN16 returns the pointed value at a specific bit position and with a
+// bitmask applied.
+func GetN16(addr *uint16, pos int, mask int) uint16 {
+	return uint16((int(*addr) >> pos) & mask)
+}
+
+// SetN16 modifies the pointed value by setting a value at a specific bit
+// position and with a bitmask applied.
+func SetN16(addr *uint16, pos int, mask int, val uint16) {
+	*addr = (*addr & (^(uint16(mask) << pos))) | (val << pos)
+}

--- a/bits/bits32.go
+++ b/bits/bits32.go
@@ -5,8 +5,7 @@
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
 
-// Package bits provides primitives for bitwise operations on 32/64 bit
-// registers.
+// Package bits provides primitives for bitwise operations on registers.
 package bits
 
 // Get returns whether a specific bit position is set at the pointed value.

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -10,6 +10,7 @@ package lan9696evb
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/usbarmory/tamago/bits"
 	"github.com/usbarmory/tamago/internal/reg"
@@ -22,6 +23,9 @@ const (
 	PHY_ADDR            = 0x03
 	MAC_FID             = 1
 	ManagementPortIndex = PORT29
+
+	managementLinkTimeout      = 10 * time.Second
+	managementLinkPollInterval = 10 * time.Millisecond
 )
 
 // On the LAN969x 24-port EVB the management network interface is port D29,
@@ -51,6 +55,37 @@ func resetInjectionFlowControl(port uint32) {
 	reg.Set(DEV_TX_STOP_WM_CFG+port*4, DEV_TX_CNT_CLR)
 }
 
+func waitManagementLink(phy *lan8840.PHY) (status lan8840.Status, err error) {
+	deadline := time.Now().Add(managementLinkTimeout)
+
+	for {
+		if status, err = phy.Status(); err != nil {
+			return
+		}
+
+		if status.Link && status.AutoNegotiationComplete {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			return status, fmt.Errorf("timed out waiting for management PHY link")
+		}
+
+		time.Sleep(managementLinkPollInterval)
+	}
+
+	switch {
+	case status.Speed == 10:
+		return status, fmt.Errorf("unsupported 10 Mbps management link")
+	case !status.FullDuplex:
+		return status, fmt.Errorf("unsupported half-duplex management link")
+	case status.Speed != 100 && status.Speed != 1000:
+		return status, fmt.Errorf("management PHY has no common advertised mode")
+	}
+
+	return
+}
+
 func enablePort() (err error) {
 	// Table 2-7: GPIO alternate function assignments
 	//
@@ -71,8 +106,13 @@ func enablePort() (err error) {
 		return
 	}
 
+	status, err := waitManagementLink(phy)
+	if err != nil {
+		return err
+	}
+
 	// initialize MAC controller
-	if err = initRGMII(phy.Speed()); err != nil {
+	if err = initRGMII(status.Speed); err != nil {
 		return
 	}
 

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -106,6 +106,14 @@ func enablePort() (err error) {
 		return
 	}
 
+	if err = phy.Reset(); err != nil {
+		return
+	}
+
+	if err = phy.Negotiate(); err != nil {
+		return
+	}
+
 	status, err := waitManagementLink(phy)
 	if err != nil {
 		return err

--- a/board/microchip/lan9696evb/mgmt.go
+++ b/board/microchip/lan9696evb/mgmt.go
@@ -23,9 +23,16 @@ const (
 	PHY_ADDR            = 0x03
 	MAC_FID             = 1
 	ManagementPortIndex = PORT29
+)
 
-	managementLinkTimeout      = 10 * time.Second
-	managementLinkPollInterval = 10 * time.Millisecond
+var (
+	// LinkTimeout represents the timeout for management port link
+	// establishment.
+	LinkTimeout = 10 * time.Second
+
+	// LinkPollInterval represents the grace time between management port
+	// link establishment attempts.
+	LinkPollInterval = 10 * time.Millisecond
 )
 
 // On the LAN969x 24-port EVB the management network interface is port D29,
@@ -56,7 +63,7 @@ func resetInjectionFlowControl(port uint32) {
 }
 
 func waitManagementLink(phy *lan8840.PHY) (status lan8840.Status, err error) {
-	deadline := time.Now().Add(managementLinkTimeout)
+	deadline := time.Now().Add(LinkTimeout)
 
 	for {
 		if status, err = phy.Status(); err != nil {
@@ -71,7 +78,7 @@ func waitManagementLink(phy *lan8840.PHY) (status lan8840.Status, err error) {
 			return status, fmt.Errorf("timed out waiting for management PHY link")
 		}
 
-		time.Sleep(managementLinkPollInterval)
+		time.Sleep(LinkPollInterval)
 	}
 
 	switch {

--- a/phy/microchip/lan8804/phy.go
+++ b/phy/microchip/lan8804/phy.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/usbarmory/tamago/bits"
 	"github.com/usbarmory/tamago/phy"
 )
 
@@ -108,7 +109,9 @@ func (hw *PHY) selectExtended(page int, address uint16) (err error) {
 		return errors.New("invalid extended page")
 	}
 
-	if err = hw.write(EP_ACCESS_CTRL, uint16(EP_ADDRESS<<EP_FUNCTION|page<<EP_INDEX)); err != nil {
+	ctrl := EP_ADDRESS<<EP_FUNCTION | page<<EP_INDEX
+
+	if err = hw.write(EP_ACCESS_CTRL, uint16(ctrl)); err != nil {
 		return
 	}
 
@@ -116,7 +119,9 @@ func (hw *PHY) selectExtended(page int, address uint16) (err error) {
 		return
 	}
 
-	return hw.write(EP_ACCESS_CTRL, uint16(EP_DATA<<EP_FUNCTION|page<<EP_INDEX))
+	ctrl = EP_DATA<<EP_FUNCTION | page<<EP_INDEX
+
+	return hw.write(EP_ACCESS_CTRL, uint16(ctrl))
 }
 
 // ReadExtendedRegister reads a vendor-specific Extended Page register.
@@ -152,7 +157,7 @@ func (hw *PHY) Reset() (err error) {
 			return
 		}
 
-		if control&(1<<CTRL_RESET) == 0 {
+		if bits.Get16(&control, CTRL_RESET) {
 			return
 		}
 
@@ -212,7 +217,7 @@ func (hw *PHY) Link() (up bool, err error) {
 		return
 	}
 
-	return basic&(1<<STATUS_LINK) != 0, nil
+	return bits.Get16(&basic, STATUS_LINK), nil
 }
 
 // Status returns link, auto-negotiation, speed, and duplex state.
@@ -225,8 +230,8 @@ func (hw *PHY) Status() (status Status, err error) {
 
 	hw.speed = 0
 
-	status.Link = basic&(1<<STATUS_LINK) != 0
-	status.AutoNegotiationComplete = basic&(1<<STATUS_ANEG_COMPLETE) != 0
+	status.Link = bits.Get16(&basic, STATUS_LINK)
+	status.AutoNegotiationComplete = bits.Get16(&basic, STATUS_ANEG_COMPLETE)
 
 	if !status.Link {
 		return
@@ -236,14 +241,14 @@ func (hw *PHY) Status() (status Status, err error) {
 		return
 	}
 
-	status.FullDuplex = control&(1<<CONTROL_DUPLEX) != 0
+	status.FullDuplex = bits.Get16(&control, CONTROL_DUPLEX)
 
 	switch {
-	case control&(1<<CONTROL_SPEED_1000) != 0:
+	case bits.Get16(&control, CONTROL_SPEED_1000):
 		status.Speed = 1000
-	case control&(1<<CONTROL_SPEED_100) != 0:
+	case bits.Get16(&control, CONTROL_SPEED_100):
 		status.Speed = 100
-	case control&(1<<CONTROL_SPEED_10) != 0:
+	case bits.Get16(&control, CONTROL_SPEED_10):
 		status.Speed = 10
 	default:
 		err = fmt.Errorf("invalid speed status %#x", control)

--- a/phy/microchip/lan8804/phy.go
+++ b/phy/microchip/lan8804/phy.go
@@ -105,7 +105,7 @@ func (hw *PHY) write(address int, data uint16) (err error) {
 
 func (hw *PHY) selectExtended(page int, address uint16) (err error) {
 	if page < 0 || page > 0x1f {
-		return errors.New("invalid LAN8804 extended page")
+		return errors.New("invalid extended page")
 	}
 
 	if err = hw.write(EP_ACCESS_CTRL, uint16(EP_ADDRESS<<EP_FUNCTION|page<<EP_INDEX)); err != nil {
@@ -157,7 +157,7 @@ func (hw *PHY) Reset() (err error) {
 		}
 
 		if time.Now().After(deadline) {
-			return errors.New("LAN8804 reset timeout")
+			return errors.New("reset timeout")
 		}
 
 		time.Sleep(time.Millisecond)
@@ -246,7 +246,7 @@ func (hw *PHY) Status() (status Status, err error) {
 	case control&(1<<CONTROL_SPEED_10) != 0:
 		status.Speed = 10
 	default:
-		err = fmt.Errorf("invalid LAN8804 speed status %#x", control)
+		err = fmt.Errorf("invalid speed status %#x", control)
 	}
 
 	hw.speed = status.Speed

--- a/phy/microchip/lan8804/phy.go
+++ b/phy/microchip/lan8804/phy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/usbarmory/tamago/phy"
 )
 
+// PHY registers
 const (
 	BASIC_CONTROL  = 0x00
 	BASIC_STATUS   = 0x01

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -21,8 +21,8 @@ import (
 
 // PHY registers
 const (
-	PHY_CTRL        = 0x00
-	PHY_STATUS      = 0x01
+	BASIC_CONTROL   = 0x00
+	BASIC_STATUS    = 0x01
 	PHY_ANEG_ADV    = 0x04
 	PHY_ANEG_LPA    = 0x05
 	PHY_1000_CTRL   = 0x09
@@ -30,7 +30,7 @@ const (
 
 	CTRL_RESET        = 15
 	CTRL_SPEED0       = 13
-	CTRL_ANEG         = 12
+	CTRL_ANEG_ENABLE  = 12
 	CTRL_ANEG_RESTART = 9
 	CTRL_DUPLEX       = 8
 	CTRL_SPEED1       = 6
@@ -92,26 +92,26 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	hw.speed = 0
 
 	// software reset
-	if err = hw.miim.WritePHYRegister(hw.pa, PHY_CTRL, (1 << CTRL_RESET)); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, BASIC_CONTROL, (1 << CTRL_RESET)); err != nil {
 		return
 	}
 
-	control, err := hw.wait(PHY_CTRL, 1<<CTRL_RESET, 0)
+	control, err := hw.wait(BASIC_CONTROL, 1<<CTRL_RESET, 0)
 
 	if err != nil {
 		return fmt.Errorf("could not reset PHY, %v", err)
 	}
 
 	// enable and restart auto-negotiation
-	control |= (1 << CTRL_ANEG) | (1 << CTRL_ANEG_RESTART)
+	control |= (1 << CTRL_ANEG_ENABLE) | (1 << CTRL_ANEG_RESTART)
 
-	if err = hw.miim.WritePHYRegister(hw.pa, PHY_CTRL, control); err != nil {
+	if err = hw.miim.WritePHYRegister(hw.pa, BASIC_CONTROL, control); err != nil {
 		return
 	}
 
 	statusMask := uint16((1 << STATUS_LINK) | (1 << STATUS_ANEG_COMPLETE))
 
-	if _, err = hw.wait(PHY_STATUS, statusMask, statusMask); err != nil {
+	if _, err = hw.wait(BASIC_STATUS, statusMask, statusMask); err != nil {
 		return fmt.Errorf("auto-negotiation status error, %w", err)
 	}
 

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -23,6 +23,8 @@ import (
 const (
 	BASIC_CONTROL   = 0x00
 	BASIC_STATUS    = 0x01
+	PHY_ID_1        = 0x02
+	PHY_ID_2        = 0x03
 	PHY_ANEG_ADV    = 0x04
 	PHY_ANEG_LPA    = 0x05
 	PHY_1000_CTRL   = 0x09
@@ -180,6 +182,21 @@ func (hw *PHY) Negotiate() (err error) {
 	}
 
 	return
+}
+
+// Identifier returns the PHY identifier registers as one 32-bit value.
+func (hw *PHY) Identifier() (id uint32, err error) {
+	var high, low uint16
+
+	if high, err = hw.read(PHY_ID_1); err != nil {
+		return
+	}
+
+	if low, err = hw.read(PHY_ID_2); err != nil {
+		return
+	}
+
+	return uint32(high)<<16 | uint32(low), nil
 }
 
 // Address returns the PHY address passed at [PHY.Init].

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -53,9 +53,6 @@ const (
 // Timeout is the default timeout for PHY operations.
 const Timeout = 100 * time.Millisecond
 
-// PollInterval represents the delay between PHY register polling attempts
-var PollInterval = 10 * time.Millisecond
-
 // Status represents the resolved PHY link state.
 type Status struct {
 	Link                    bool
@@ -111,37 +108,31 @@ func (hw *PHY) write(address int, data uint16) (err error) {
 	return hw.miim.WritePHYRegister(hw.pa, address, data)
 }
 
-func (hw *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
-	deadline := time.Now().Add(hw.Timeout)
-
-	for {
-		if data, err = hw.read(addr); err != nil {
-			return
-		}
-
-		if data&mask == value {
-			return
-		}
-
-		if time.Now().After(deadline) {
-			return 0, fmt.Errorf("timed out waiting for PHY register %#x", addr)
-		}
-
-		time.Sleep(PollInterval)
-	}
-}
-
 // Reset performs a software hard reset and waits for its completion.
 func (hw *PHY) Reset() (err error) {
+	var control uint16
+
 	if err = hw.write(BASIC_CONTROL, 1<<CTRL_RESET); err != nil {
 		return
 	}
 
-	if _, err = hw.wait(BASIC_CONTROL, 1<<CTRL_RESET, 0); err != nil {
-		return fmt.Errorf("could not reset PHY, %w", err)
-	}
+	deadline := time.Now().Add(hw.Timeout)
 
-	return
+	for {
+		if control, err = hw.read(BASIC_CONTROL); err != nil {
+			return
+		}
+
+		if control&(1<<CTRL_RESET) == 0 {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			return errors.New("LAN8840 reset timeout")
+		}
+
+		time.Sleep(time.Millisecond)
+	}
 }
 
 // Negotiate enables and restarts auto-negotiation.

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -117,7 +117,7 @@ func (hw *PHY) Reset() (err error) {
 			return
 		}
 
-		if bits.Get16(&control, CTRL_RESET) {
+		if !bits.Get16(&control, CTRL_RESET) {
 			return
 		}
 

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -61,11 +61,27 @@ type PHY struct {
 	speed int
 }
 
+func (hw *PHY) read(address int) (data uint16, err error) {
+	if hw.miim == nil {
+		return 0, errors.New("invalid PHY instance")
+	}
+
+	return hw.miim.ReadPHYRegister(hw.pa, address)
+}
+
+func (hw *PHY) write(address int, data uint16) (err error) {
+	if hw.miim == nil {
+		return errors.New("invalid PHY instance")
+	}
+
+	return hw.miim.WritePHYRegister(hw.pa, address, data)
+}
+
 func (hw *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
 	deadline := time.Now().Add(WaitTimeout)
 
 	for {
-		if data, err = hw.miim.ReadPHYRegister(hw.pa, addr); err != nil {
+		if data, err = hw.read(addr); err != nil {
 			return
 		}
 
@@ -92,7 +108,7 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	hw.speed = 0
 
 	// software reset
-	if err = hw.miim.WritePHYRegister(hw.pa, BASIC_CONTROL, (1 << CTRL_RESET)); err != nil {
+	if err = hw.write(BASIC_CONTROL, (1 << CTRL_RESET)); err != nil {
 		return
 	}
 
@@ -105,7 +121,7 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	// enable and restart auto-negotiation
 	control |= (1 << CTRL_ANEG_ENABLE) | (1 << CTRL_ANEG_RESTART)
 
-	if err = hw.miim.WritePHYRegister(hw.pa, BASIC_CONTROL, control); err != nil {
+	if err = hw.write(BASIC_CONTROL, control); err != nil {
 		return
 	}
 
@@ -125,15 +141,11 @@ func (hw *PHY) Negotiate() (err error) {
 
 	hw.speed = 0
 
-	if hw.miim == nil {
-		return errors.New("invalid PHY instance")
-	}
-
-	if local, err = hw.miim.ReadPHYRegister(hw.pa, PHY_1000_CTRL); err != nil {
+	if local, err = hw.read(PHY_1000_CTRL); err != nil {
 		return fmt.Errorf("could not read 1000BASE-T control register, %v", err)
 	}
 
-	if partner, err = hw.miim.ReadPHYRegister(hw.pa, PHY_1000_STATUS); err != nil {
+	if partner, err = hw.read(PHY_1000_STATUS); err != nil {
 		return fmt.Errorf("could not read 1000BASE-T status register, %v", err)
 	}
 
@@ -146,11 +158,11 @@ func (hw *PHY) Negotiate() (err error) {
 		return fmt.Errorf("unsupported half-duplex management link")
 	}
 
-	if local, err = hw.miim.ReadPHYRegister(hw.pa, PHY_ANEG_ADV); err != nil {
+	if local, err = hw.read(PHY_ANEG_ADV); err != nil {
 		return fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
 	}
 
-	if partner, err = hw.miim.ReadPHYRegister(hw.pa, PHY_ANEG_LPA); err != nil {
+	if partner, err = hw.read(PHY_ANEG_LPA); err != nil {
 		return fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
 	}
 

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -50,10 +50,10 @@ const (
 	ANEG_LPA_1000_FULL = 1 << 11
 )
 
-// WaitTimeout represents the timeout for PHY register writes
-var WaitTimeout = 10 * time.Second
+// Timeout is the default timeout for PHY operations.
+const Timeout = 100 * time.Millisecond
 
-// PollInterval represents the delay between PHY register write attempts
+// PollInterval represents the delay between PHY register polling attempts
 var PollInterval = 10 * time.Millisecond
 
 // Status represents the resolved PHY link state.
@@ -66,9 +66,33 @@ type Status struct {
 
 // PHY represents the LAN8840 Ethernet PHY instance.
 type PHY struct {
+	// Timeout for PHY operations
+	Timeout time.Duration
+
 	miim  phy.MIIM
 	pa    int
 	speed int
+}
+
+// Init initializes the PHY, resets it, and starts auto-negotiation.
+func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
+	if miim == nil || addr < 0 || addr > 0x07 {
+		return errors.New("invalid PHY instance")
+	}
+
+	hw.miim = miim
+	hw.pa = addr
+	hw.speed = 0
+
+	if hw.Timeout == 0 {
+		hw.Timeout = Timeout
+	}
+
+	if err = hw.Reset(); err != nil {
+		return
+	}
+
+	return hw.Negotiate()
 }
 
 func (hw *PHY) read(address int) (data uint16, err error) {
@@ -88,7 +112,7 @@ func (hw *PHY) write(address int, data uint16) (err error) {
 }
 
 func (hw *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error) {
-	deadline := time.Now().Add(WaitTimeout)
+	deadline := time.Now().Add(hw.Timeout)
 
 	for {
 		if data, err = hw.read(addr); err != nil {
@@ -107,47 +131,14 @@ func (hw *PHY) wait(addr int, mask uint16, value uint16) (data uint16, err error
 	}
 }
 
-// Init initializes the PHY and performs [PHY.Negotiate].
-func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
-	if miim == nil {
-		return errors.New("invalid PHY instance")
-	}
-
-	hw.miim = miim
-	hw.pa = addr
-	hw.speed = 0
-
-	// software reset
-	if err = hw.write(BASIC_CONTROL, (1 << CTRL_RESET)); err != nil {
+// Reset performs a software hard reset and waits for its completion.
+func (hw *PHY) Reset() (err error) {
+	if err = hw.write(BASIC_CONTROL, 1<<CTRL_RESET); err != nil {
 		return
 	}
 
 	if _, err = hw.wait(BASIC_CONTROL, 1<<CTRL_RESET, 0); err != nil {
-		return fmt.Errorf("could not reset PHY, %v", err)
-	}
-
-	if err = hw.Negotiate(); err != nil {
-		return
-	}
-
-	statusMask := uint16((1 << STATUS_LINK) | (1 << STATUS_ANEG_COMPLETE))
-
-	if _, err = hw.wait(BASIC_STATUS, statusMask, statusMask); err != nil {
-		return fmt.Errorf("auto-negotiation status error, %w", err)
-	}
-
-	var status Status
-	if status, err = hw.Status(); err != nil {
-		return
-	}
-
-	switch {
-	case status.Speed == 10:
-		return errors.New("unsupported 10 Mbps management link")
-	case !status.FullDuplex:
-		return errors.New("unsupported half-duplex management link")
-	case status.Speed != 100 && status.Speed != 1000:
-		return errors.New("management PHY has no common advertised mode")
+		return fmt.Errorf("could not reset PHY, %w", err)
 	}
 
 	return

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -68,8 +68,7 @@ type PHY struct {
 	speed int
 }
 
-// Init initializes the PHY, resets it, and starts auto-negotiation without
-// waiting for link establishment.
+// Init initializes a LAN8840 PHY instance for register access.
 func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	if miim == nil || addr < 0 || addr > 0x07 {
 		return errors.New("invalid PHY instance")
@@ -83,11 +82,7 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 		hw.Timeout = Timeout
 	}
 
-	if err = hw.Reset(); err != nil {
-		return
-	}
-
-	return hw.Negotiate()
+	return
 }
 
 func (hw *PHY) read(address int) (data uint16, err error) {

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -122,16 +122,11 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 		return
 	}
 
-	control, err := hw.wait(BASIC_CONTROL, 1<<CTRL_RESET, 0)
-
-	if err != nil {
+	if _, err = hw.wait(BASIC_CONTROL, 1<<CTRL_RESET, 0); err != nil {
 		return fmt.Errorf("could not reset PHY, %v", err)
 	}
 
-	// enable and restart auto-negotiation
-	control |= (1 << CTRL_ANEG_ENABLE) | (1 << CTRL_ANEG_RESTART)
-
-	if err = hw.write(BASIC_CONTROL, control); err != nil {
+	if err = hw.Negotiate(); err != nil {
 		return
 	}
 
@@ -141,73 +136,36 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 		return fmt.Errorf("auto-negotiation status error, %w", err)
 	}
 
-	return hw.Negotiate()
-}
-
-func (hw *PHY) resolveMode() (speed int, fullDuplex bool, err error) {
-	var local, partner uint16
-
-	if local, err = hw.read(PHY_1000_CTRL); err != nil {
-		return 0, false, fmt.Errorf("could not read 1000BASE-T control register, %v", err)
-	}
-
-	if partner, err = hw.read(PHY_1000_STATUS); err != nil {
-		return 0, false, fmt.Errorf("could not read 1000BASE-T status register, %v", err)
-	}
-
-	switch {
-	case local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0:
-		return 1000, true, nil
-	case local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0:
-		return 1000, false, nil
-	}
-
-	if local, err = hw.read(PHY_ANEG_ADV); err != nil {
-		return 0, false, fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
-	}
-
-	if partner, err = hw.read(PHY_ANEG_LPA); err != nil {
-		return 0, false, fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
-	}
-
-	common := local & partner
-
-	switch {
-	case common&ANEG_ADV_100_FULL != 0:
-		return 100, true, nil
-	case common&ANEG_ADV_100_HALF != 0:
-		return 100, false, nil
-	case common&ANEG_ADV_10_FULL != 0:
-		return 10, true, nil
-	case common&ANEG_ADV_10_HALF != 0:
-		return 10, false, nil
-	default:
-		return 0, false, errors.New("management PHY has no common advertised mode")
-	}
-}
-
-// Negotiate refreshes the PHY auto-negotiation status, currently only 100/1000
-// Mbps Auto-Negotiation (Full-duplex) is supported.
-func (hw *PHY) Negotiate() (err error) {
-	hw.speed = 0
-
-	var speed int
-	var fullDuplex bool
-
-	if speed, fullDuplex, err = hw.resolveMode(); err != nil {
+	var status Status
+	if status, err = hw.Status(); err != nil {
 		return
 	}
 
 	switch {
-	case speed == 10:
+	case status.Speed == 10:
 		return errors.New("unsupported 10 Mbps management link")
-	case !fullDuplex:
+	case !status.FullDuplex:
 		return errors.New("unsupported half-duplex management link")
+	case status.Speed != 100 && status.Speed != 1000:
+		return errors.New("management PHY has no common advertised mode")
 	}
 
-	hw.speed = speed
-
 	return
+}
+
+// Negotiate enables and restarts auto-negotiation.
+func (hw *PHY) Negotiate() (err error) {
+	var control uint16
+
+	hw.speed = 0
+
+	if control, err = hw.read(BASIC_CONTROL); err != nil {
+		return
+	}
+
+	control |= (1 << CTRL_ANEG_ENABLE) | (1 << CTRL_ANEG_RESTART)
+
+	return hw.write(BASIC_CONTROL, control)
 }
 
 // Identifier returns the PHY identifier registers as one 32-bit value.
@@ -263,8 +221,47 @@ func (hw *PHY) Status() (status Status, err error) {
 		return
 	}
 
-	if status.Speed, status.FullDuplex, err = hw.resolveMode(); err != nil {
-		return
+	var local, partner uint16
+
+	if local, err = hw.read(PHY_1000_CTRL); err != nil {
+		return status, fmt.Errorf("could not read 1000BASE-T control register, %v", err)
+	}
+
+	if partner, err = hw.read(PHY_1000_STATUS); err != nil {
+		return status, fmt.Errorf("could not read 1000BASE-T status register, %v", err)
+	}
+
+	switch {
+	case local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0:
+		status.Speed = 1000
+		status.FullDuplex = true
+	case local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0:
+		status.Speed = 1000
+	default:
+		if local, err = hw.read(PHY_ANEG_ADV); err != nil {
+			return status, fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
+		}
+
+		if partner, err = hw.read(PHY_ANEG_LPA); err != nil {
+			return status, fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
+		}
+
+		common := local & partner
+
+		switch {
+		case common&ANEG_ADV_100_FULL != 0:
+			status.Speed = 100
+			status.FullDuplex = true
+		case common&ANEG_ADV_100_HALF != 0:
+			status.Speed = 100
+		case common&ANEG_ADV_10_FULL != 0:
+			status.Speed = 10
+			status.FullDuplex = true
+		case common&ANEG_ADV_10_HALF != 0:
+			status.Speed = 10
+		default:
+			return status, errors.New("management PHY has no common advertised mode")
+		}
 	}
 
 	hw.speed = status.Speed

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -217,7 +217,7 @@ func (hw *PHY) Status() (status Status, err error) {
 	status.Link = basic&(1<<STATUS_LINK) != 0
 	status.AutoNegotiationComplete = basic&(1<<STATUS_ANEG_COMPLETE) != 0
 
-	if !status.Link {
+	if !status.Link || !status.AutoNegotiationComplete {
 		return
 	}
 

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -56,6 +56,14 @@ var WaitTimeout = 10 * time.Second
 // PollInterval represents the delay between PHY register write attempts
 var PollInterval = 10 * time.Millisecond
 
+// Status represents the resolved PHY link state.
+type Status struct {
+	Link                    bool
+	AutoNegotiationComplete bool
+	Speed                   int
+	FullDuplex              bool
+}
+
 // PHY represents the LAN8840 Ethernet PHY instance.
 type PHY struct {
 	miim  phy.MIIM
@@ -136,50 +144,68 @@ func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	return hw.Negotiate()
 }
 
-// Negotiate refreshes the PHY auto-negotiation status, currently only 100/1000
-// Mbps Auto-Negotiation (Full-duplex) is supported.
-func (hw *PHY) Negotiate() (err error) {
+func (hw *PHY) resolveMode() (speed int, fullDuplex bool, err error) {
 	var local, partner uint16
 
-	hw.speed = 0
-
 	if local, err = hw.read(PHY_1000_CTRL); err != nil {
-		return fmt.Errorf("could not read 1000BASE-T control register, %v", err)
+		return 0, false, fmt.Errorf("could not read 1000BASE-T control register, %v", err)
 	}
 
 	if partner, err = hw.read(PHY_1000_STATUS); err != nil {
-		return fmt.Errorf("could not read 1000BASE-T status register, %v", err)
+		return 0, false, fmt.Errorf("could not read 1000BASE-T status register, %v", err)
 	}
 
-	if local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0 {
-		hw.speed = 1000
-		return
-	}
-
-	if local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0 {
-		return fmt.Errorf("unsupported half-duplex management link")
+	switch {
+	case local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0:
+		return 1000, true, nil
+	case local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0:
+		return 1000, false, nil
 	}
 
 	if local, err = hw.read(PHY_ANEG_ADV); err != nil {
-		return fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
+		return 0, false, fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
 	}
 
 	if partner, err = hw.read(PHY_ANEG_LPA); err != nil {
-		return fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
+		return 0, false, fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
 	}
 
 	common := local & partner
 
 	switch {
 	case common&ANEG_ADV_100_FULL != 0:
-		hw.speed = 100
+		return 100, true, nil
 	case common&ANEG_ADV_100_HALF != 0:
-		return fmt.Errorf("unsupported half-duplex management link")
-	case common&(ANEG_ADV_10_FULL|ANEG_ADV_10_HALF) != 0:
-		return fmt.Errorf("unsupported 10 Mbps management link")
+		return 100, false, nil
+	case common&ANEG_ADV_10_FULL != 0:
+		return 10, true, nil
+	case common&ANEG_ADV_10_HALF != 0:
+		return 10, false, nil
 	default:
-		return fmt.Errorf("management PHY has no common advertised mode")
+		return 0, false, errors.New("management PHY has no common advertised mode")
 	}
+}
+
+// Negotiate refreshes the PHY auto-negotiation status, currently only 100/1000
+// Mbps Auto-Negotiation (Full-duplex) is supported.
+func (hw *PHY) Negotiate() (err error) {
+	hw.speed = 0
+
+	var speed int
+	var fullDuplex bool
+
+	if speed, fullDuplex, err = hw.resolveMode(); err != nil {
+		return
+	}
+
+	switch {
+	case speed == 10:
+		return errors.New("unsupported 10 Mbps management link")
+	case !fullDuplex:
+		return errors.New("unsupported half-duplex management link")
+	}
+
+	hw.speed = speed
 
 	return
 }
@@ -197,6 +223,53 @@ func (hw *PHY) Identifier() (id uint32, err error) {
 	}
 
 	return uint32(high)<<16 | uint32(low), nil
+}
+
+func (hw *PHY) link() (basic uint16, err error) {
+	// STATUS_LINK is latch-low; the first read clears stale link state.
+	if _, err = hw.read(BASIC_STATUS); err != nil {
+		return
+	}
+
+	return hw.read(BASIC_STATUS)
+}
+
+// Link reports whether the PHY link is up. The status register is read twice
+// because its link bit is latched low.
+func (hw *PHY) Link() (up bool, err error) {
+	var basic uint16
+
+	if basic, err = hw.link(); err != nil {
+		return
+	}
+
+	return basic&(1<<STATUS_LINK) != 0, nil
+}
+
+// Status returns link, auto-negotiation, speed, and duplex state.
+func (hw *PHY) Status() (status Status, err error) {
+	var basic uint16
+
+	if basic, err = hw.link(); err != nil {
+		return
+	}
+
+	hw.speed = 0
+
+	status.Link = basic&(1<<STATUS_LINK) != 0
+	status.AutoNegotiationComplete = basic&(1<<STATUS_ANEG_COMPLETE) != 0
+
+	if !status.Link {
+		return
+	}
+
+	if status.Speed, status.FullDuplex, err = hw.resolveMode(); err != nil {
+		return
+	}
+
+	hw.speed = status.Speed
+
+	return
 }
 
 // Address returns the PHY address passed at [PHY.Init].

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/usbarmory/tamago/bits"
 	"github.com/usbarmory/tamago/phy"
 )
 
@@ -34,17 +35,17 @@ const (
 	CTRL_ANEG_ENABLE  = 12
 	CTRL_ANEG_RESTART = 9
 
-	STATUS_LINK          = 2
 	STATUS_ANEG_COMPLETE = 5
+	STATUS_LINK          = 2
 
-	ANEG_ADV_10_HALF   = 1 << 5
-	ANEG_ADV_10_FULL   = 1 << 6
-	ANEG_ADV_100_HALF  = 1 << 7
-	ANEG_ADV_100_FULL  = 1 << 8
-	ANEG_ADV_1000_HALF = 1 << 8
-	ANEG_ADV_1000_FULL = 1 << 9
-	ANEG_LPA_1000_HALF = 1 << 10
-	ANEG_LPA_1000_FULL = 1 << 11
+	ANEG_LPA_1000_HALF = 10
+	ANEG_LPA_1000_FULL = 11
+	ANEG_ADV_1000_FULL = 9
+	ANEG_ADV_1000_HALF = 8
+	ANEG_ADV_100_FULL  = 8
+	ANEG_ADV_100_HALF  = 7
+	ANEG_ADV_10_FULL   = 6
+	ANEG_ADV_10_HALF   = 5
 )
 
 // Timeout is the default timeout for PHY operations.
@@ -116,12 +117,12 @@ func (hw *PHY) Reset() (err error) {
 			return
 		}
 
-		if control&(1<<CTRL_RESET) == 0 {
+		if bits.Get16(&control, CTRL_RESET) {
 			return
 		}
 
 		if time.Now().After(deadline) {
-			return errors.New("LAN8840 reset timeout")
+			return errors.New("reset timeout")
 		}
 
 		time.Sleep(time.Millisecond)
@@ -176,12 +177,12 @@ func (hw *PHY) Link() (up bool, err error) {
 		return
 	}
 
-	return basic&(1<<STATUS_LINK) != 0, nil
+	return bits.Get16(&basic, STATUS_LINK), nil
 }
 
 // Status returns link, auto-negotiation, speed, and duplex state.
 func (hw *PHY) Status() (status Status, err error) {
-	var basic uint16
+	var basic, local, partner uint16
 
 	if basic, err = hw.link(); err != nil {
 		return
@@ -189,14 +190,12 @@ func (hw *PHY) Status() (status Status, err error) {
 
 	hw.speed = 0
 
-	status.Link = basic&(1<<STATUS_LINK) != 0
-	status.AutoNegotiationComplete = basic&(1<<STATUS_ANEG_COMPLETE) != 0
+	status.Link = bits.Get16(&basic, STATUS_LINK)
+	status.AutoNegotiationComplete = bits.Get16(&basic, STATUS_ANEG_COMPLETE)
 
 	if !status.Link || !status.AutoNegotiationComplete {
 		return
 	}
-
-	var local, partner uint16
 
 	if local, err = hw.read(PHY_1000_CTRL); err != nil {
 		return status, fmt.Errorf("could not read 1000BASE-T control register, %w", err)
@@ -207,10 +206,10 @@ func (hw *PHY) Status() (status Status, err error) {
 	}
 
 	switch {
-	case local&ANEG_ADV_1000_FULL != 0 && partner&ANEG_LPA_1000_FULL != 0:
+	case bits.Get16(&local, ANEG_ADV_1000_FULL) && bits.Get16(&partner, ANEG_LPA_1000_FULL):
 		status.Speed = 1000
 		status.FullDuplex = true
-	case local&ANEG_ADV_1000_HALF != 0 && partner&ANEG_LPA_1000_HALF != 0:
+	case bits.Get16(&local, ANEG_ADV_1000_HALF) && bits.Get16(&partner, ANEG_LPA_1000_HALF):
 		status.Speed = 1000
 	default:
 		if local, err = hw.read(PHY_ANEG_ADV); err != nil {
@@ -224,15 +223,15 @@ func (hw *PHY) Status() (status Status, err error) {
 		common := local & partner
 
 		switch {
-		case common&ANEG_ADV_100_FULL != 0:
+		case bits.Get16(&common, ANEG_ADV_100_FULL):
 			status.Speed = 100
 			status.FullDuplex = true
-		case common&ANEG_ADV_100_HALF != 0:
+		case bits.Get16(&common, ANEG_ADV_100_HALF):
 			status.Speed = 100
-		case common&ANEG_ADV_10_FULL != 0:
+		case bits.Get16(&common, ANEG_ADV_10_FULL):
 			status.Speed = 10
 			status.FullDuplex = true
-		case common&ANEG_ADV_10_HALF != 0:
+		case bits.Get16(&common, ANEG_ADV_10_HALF):
 			status.Speed = 10
 		default:
 			return status, errors.New("PHY has no common advertised mode")

--- a/phy/microchip/lan8840/phy.go
+++ b/phy/microchip/lan8840/phy.go
@@ -31,11 +31,8 @@ const (
 	PHY_1000_STATUS = 0x0a
 
 	CTRL_RESET        = 15
-	CTRL_SPEED0       = 13
 	CTRL_ANEG_ENABLE  = 12
 	CTRL_ANEG_RESTART = 9
-	CTRL_DUPLEX       = 8
-	CTRL_SPEED1       = 6
 
 	STATUS_LINK          = 2
 	STATUS_ANEG_COMPLETE = 5
@@ -61,7 +58,7 @@ type Status struct {
 	FullDuplex              bool
 }
 
-// PHY represents the LAN8840 Ethernet PHY instance.
+// PHY represents a LAN8840 PHY port.
 type PHY struct {
 	// Timeout for PHY operations
 	Timeout time.Duration
@@ -71,7 +68,8 @@ type PHY struct {
 	speed int
 }
 
-// Init initializes the PHY, resets it, and starts auto-negotiation.
+// Init initializes the PHY, resets it, and starts auto-negotiation without
+// waiting for link establishment.
 func (hw *PHY) Init(addr int, miim phy.MIIM) (err error) {
 	if miim == nil || addr < 0 || addr > 0x07 {
 		return errors.New("invalid PHY instance")
@@ -206,11 +204,11 @@ func (hw *PHY) Status() (status Status, err error) {
 	var local, partner uint16
 
 	if local, err = hw.read(PHY_1000_CTRL); err != nil {
-		return status, fmt.Errorf("could not read 1000BASE-T control register, %v", err)
+		return status, fmt.Errorf("could not read 1000BASE-T control register, %w", err)
 	}
 
 	if partner, err = hw.read(PHY_1000_STATUS); err != nil {
-		return status, fmt.Errorf("could not read 1000BASE-T status register, %v", err)
+		return status, fmt.Errorf("could not read 1000BASE-T status register, %w", err)
 	}
 
 	switch {
@@ -221,11 +219,11 @@ func (hw *PHY) Status() (status Status, err error) {
 		status.Speed = 1000
 	default:
 		if local, err = hw.read(PHY_ANEG_ADV); err != nil {
-			return status, fmt.Errorf("could not read auto-negotiation advertisement register, %v", err)
+			return status, fmt.Errorf("could not read auto-negotiation advertisement register, %w", err)
 		}
 
 		if partner, err = hw.read(PHY_ANEG_LPA); err != nil {
-			return status, fmt.Errorf("could not read auto-negotiation link partner ability register, %v", err)
+			return status, fmt.Errorf("could not read auto-negotiation link partner ability register, %w", err)
 		}
 
 		common := local & partner
@@ -242,7 +240,7 @@ func (hw *PHY) Status() (status Status, err error) {
 		case common&ANEG_ADV_10_HALF != 0:
 			status.Speed = 10
 		default:
-			return status, errors.New("management PHY has no common advertised mode")
+			return status, errors.New("PHY has no common advertised mode")
 		}
 	}
 
@@ -256,7 +254,7 @@ func (hw *PHY) Address() int {
 	return hw.pa
 }
 
-// Speed returns the PHY auto-negotiated speed.
+// Speed returns the last resolved PHY link speed.
 func (hw *PHY) Speed() int {
 	return hw.speed
 }


### PR DESCRIPTION
Align the LAN8840 driver with the LAN8804 driver where both PHYs provide equivalent functionality.

   - Align common Clause 22 register and field names.
   - Add Reset, Identifier, Link, and Status to LAN8840.
   - Make Negotiate enable and restart auto-negotiation.
   - Make Init configure register access without resetting or negotiating.
   - Validate the LAN8840 PHY address range.
   - Use per-instance reset timeout configuration.
   - Report resolved link speed and duplex from auto-negotiation state.

Move LAN8840 reset, negotiation, link waiting, management-mode policy, and RGMII speed configuration into the LAN9696 EVB board integration. The board continues to return from management-port initialization only after the link is ready.